### PR TITLE
Remove `console.log` call

### DIFF
--- a/packages/alpine/src/index.ts
+++ b/packages/alpine/src/index.ts
@@ -204,8 +204,6 @@ const syncSyntheticMethodInput = (el: Element, method: RequestMethod) => {
         return
     }
 
-    console.log('here')
-
     const input = el.insertAdjacentElement('afterbegin', document.createElement('input'))
 
     if (input === null) {


### PR DESCRIPTION
Just trying to start this unreleased Alpine plugin on my TALL project, but it logged a message on the console. I assume this is just a `console.log` for debugging purpose and shouldn't be there, so I'm proposing to delete it.
