### PR TITLE
[0.1.x] Ensure event listener is only bound once

### DIFF
--- a/packages/react-inertia/package.json
+++ b/packages/react-inertia/package.json
@@ -28,7 +28,8 @@
         "node": ">=14"
     },
     "peerDependencies": {
-        "@inertiajs/react": "^1.0.0"
+        "@inertiajs/react": "^1.0.0",
+        "react": "^18.0.0"
     },
     "dependencies": {
         "laravel-precognition": "^0.2.0",

--- a/packages/react-inertia/src/index.ts
+++ b/packages/react-inertia/src/index.ts
@@ -1,8 +1,11 @@
 import { Config, NamedInputEvent, RequestMethod, SimpleValidationErrors, toSimpleValidationErrors, ValidationConfig, ValidationErrors } from 'laravel-precognition'
 import { useForm as usePrecognitiveForm } from 'laravel-precognition-react'
 import { useForm as useInertiaForm } from '@inertiajs/react'
+import { useRef } from 'react'
 
 export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod, url: string, inputs: Data, config: ValidationConfig = {}): any => {
+    const booted = useRef<boolean>(false)
+
     /**
      * The Inertia form.
      */
@@ -12,18 +15,6 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
      * The React form.
      */
     const precognitiveForm = usePrecognitiveForm(method, url, inputs, config)
-
-    /**
-     * Setup event listeners.
-     */
-    precognitiveForm.validator().on('errorsChanged', () => {
-        inertiaClearErrors()
-
-        inertiaSetError(
-            // @ts-expect-error
-            toSimpleValidationErrors(precognitiveForm.validator().errors())
-        )
-    })
 
     /**
      * The Inertia submit function.
@@ -49,6 +40,22 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
      * The Inertia set data function.
      */
     const inertiaSetData = inertiaForm.setData.bind(inertiaForm)
+
+    if (! booted.current) {
+        /**
+         * Setup event listeners.
+         */
+        precognitiveForm.validator().on('errorsChanged', () => {
+            inertiaClearErrors()
+
+            inertiaSetError(
+                // @ts-expect-error
+                toSimpleValidationErrors(precognitiveForm.validator().errors())
+            )
+        })
+
+        booted.current = true
+    }
 
     /**
      * Patch the form.


### PR DESCRIPTION
We are currently re-binding the event listener on each render. Leaning on a "booted" ref to determine if it's the first render.