### PR TITLE
[0.1.x] Standardise support for uppercase method

### DIFF
--- a/packages/react-inertia/src/index.ts
+++ b/packages/react-inertia/src/index.ts
@@ -3,6 +3,9 @@ import { useForm as usePrecognitiveForm } from 'laravel-precognition-react'
 import { useForm as useInertiaForm } from '@inertiajs/react'
 
 export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod, url: string, inputs: Data, config: ValidationConfig = {}): any => {
+    // @ts-expect-error
+    method = method.toLowerCase()
+
     /**
      * The Inertia form.
      */

--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -3,6 +3,9 @@ import { useForm as usePrecognitiveForm } from 'laravel-precognition-vue'
 import { useForm as useInertiaForm } from '@inertiajs/vue3'
 
 export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod, url: string, inputs: Data, config: ValidationConfig = {}): any => {
+    // @ts-expect-error
+    method = method.toLowerCase()
+
     /**
      * The Inertia form.
      */


### PR DESCRIPTION
Couple of places where we aren't converting uppercase methods, e.g., `POST`, to the expected lowercase version.