### PR TITLE
[0.3.x] Use Inertia's processing property

### DIFF
--- a/packages/alpine/package.json
+++ b/packages/alpine/package.json
@@ -30,7 +30,7 @@
         "alpinejs": "^3.12.1"
     },
     "dependencies": {
-        "laravel-precognition": "^0.2.0",
+        "laravel-precognition": "^0.3.0",
         "lodash.clonedeep": "^4.5.0",
         "lodash.get": "^4.4.2",
         "lodash.set": "^4.3.2"

--- a/packages/react-inertia/package.json
+++ b/packages/react-inertia/package.json
@@ -32,8 +32,8 @@
         "react": "^18.0.0"
     },
     "dependencies": {
-        "laravel-precognition": "^0.2.0",
-        "laravel-precognition-react": "^0.2.0"
+        "laravel-precognition": "^0.3.0",
+        "laravel-precognition-react": "^0.3.0"
     },
     "devDependencies": {
         "@types/react-dom": "^18.2.4",

--- a/packages/react-inertia/src/index.ts
+++ b/packages/react-inertia/src/index.ts
@@ -64,7 +64,6 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
      * Patch the form.
      */
     return Object.assign(inertiaForm, {
-        processing: precognitiveForm.processing,
         validating: precognitiveForm.validating,
         touched: precognitiveForm.touched,
         valid: precognitiveForm.valid,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -30,7 +30,7 @@
         "react": "^18.0.0"
     },
     "dependencies": {
-        "laravel-precognition": "^0.2.0",
+        "laravel-precognition": "^0.3.0",
         "lodash.clonedeep": "^4.5.0",
         "lodash.get": "^4.4.2",
         "lodash.set": "^4.3.2"

--- a/packages/vue-inertia/package.json
+++ b/packages/vue-inertia/package.json
@@ -32,8 +32,8 @@
         "@inertiajs/vue3": "^1.0.0"
     },
     "dependencies": {
-        "laravel-precognition": "^0.2.0",
-        "laravel-precognition-vue": "^0.2.0"
+        "laravel-precognition": "^0.3.0",
+        "laravel-precognition-vue": "^0.3.0"
     },
     "devDependencies": {
         "typescript": "^5.0.0",

--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -52,7 +52,6 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
      * Patch the form.
      */
     return Object.assign(inertiaForm, {
-        processing: precognitiveForm.processing,
         validating: precognitiveForm.validating,
         touched: precognitiveForm.touched,
         valid: precognitiveForm.valid,

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -30,7 +30,7 @@
         "vue": "^3.0.0"
     },
     "dependencies": {
-        "laravel-precognition": "^0.2.0",
+        "laravel-precognition": "^0.3.0",
         "lodash.clonedeep": "^4.5.0",
         "lodash.get": "^4.4.2",
         "lodash.set": "^4.3.2"


### PR DESCRIPTION
This fixes an issue in React w/ Inertia where the `processing` property was not responding correctly.

Although the issue isn't present in the Vue version due to the different way that Vue works under the hood, for consistency we are also removing the monkey-patched property from the Vue w/ Inertia package and relying property already provided by Inertia.

fixes #12

I've also had to update the version constraint, as it is currently broken after the latest release.