### PR TITLE
[0.3.x] Improve versioning

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,11 @@
 # Release Instructions
 
+The following commands should be run when doing a release, where `{version}` is `major`, `minor`, or `patch`.
+
+```sh
+bin/release {version}
+git push
+npm publish
+```
+
 Releases are managed by [@taylorotwell](https://github.com/taylorotwell), [@jessarcher](https://github.com/jessarcher), and [@timacdonald](https://github.com/timacdonald) for this repository.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,8 @@
 The following commands should be run when doing a release, where `{semver-type}` is `major`, `minor`, or `patch`.
 
 ```sh
+npm install --workspaces
+npm run build --workspaces
 bin/release {semver-type}
 git tag "{version}"
 git push origin main

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,9 +1,9 @@
 # Release Instructions
 
-The following commands should be run when doing a release, where `{version}` is `major`, `minor`, or `patch`.
+The following commands should be run when doing a release, where `{semver-type}` is `major`, `minor`, or `patch`.
 
 ```sh
-bin/release {version}
+bin/release {semver-type}
 git push
 npm publish
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,8 +4,10 @@ The following commands should be run when doing a release, where `{semver-type}`
 
 ```sh
 bin/release {semver-type}
-git push
-npm publish
+git tag "{version}"
+git push origin main
+git push origin --tags
+npm publish --workspaces
 ```
 
 Releases are managed by [@taylorotwell](https://github.com/taylorotwell), [@jessarcher](https://github.com/jessarcher), and [@timacdonald](https://github.com/timacdonald) for this repository.

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Make sure the release tag is provided.
+if (( "$#" != 1 ))
+then
+    echo "Version type has to be provided: major|minor|patch."
+
+    exit 1
+fi
+
+npm version $1 \
+    --workspace=packages/core \
+    --workspace=packages/react \
+    --workspace=packages/react-inertia \
+    --workspace=packages/vue \
+    --workspace=packages/vue-inertia \
+    --workspace=packages/alpine

--- a/packages/alpine/package.json
+++ b/packages/alpine/package.json
@@ -21,7 +21,8 @@
     ],
     "scripts": {
         "build": "rm -rf dist && tsc",
-        "prepublishOnly": "npm run build"
+        "prepublishOnly": "npm run build",
+        "version": "npm pkg set dependencies.laravel-precognition=$npm_package_version"
     },
     "engines": {
         "node": ">=14"
@@ -30,7 +31,7 @@
         "alpinejs": "^3.12.1"
     },
     "dependencies": {
-        "laravel-precognition": "^0.3.0",
+        "laravel-precognition": "0.3.1",
         "lodash.clonedeep": "^4.5.0",
         "lodash.get": "^4.4.2",
         "lodash.set": "^4.3.2"

--- a/packages/react-inertia/package.json
+++ b/packages/react-inertia/package.json
@@ -22,7 +22,8 @@
     ],
     "scripts": {
         "build": "rm -rf dist && tsc",
-        "prepublishOnly": "npm run build"
+        "prepublishOnly": "npm run build",
+        "version": "npm pkg set dependencies.laravel-precognition=$npm_package_version && npm pkg set dependencies.laravel-precognition-react=$npm_package_version"
     },
     "engines": {
         "node": ">=14"
@@ -32,8 +33,8 @@
         "react": "^18.0.0"
     },
     "dependencies": {
-        "laravel-precognition": "^0.3.0",
-        "laravel-precognition-react": "^0.3.0"
+        "laravel-precognition": "0.3.1",
+        "laravel-precognition-react": "0.3.1"
     },
     "devDependencies": {
         "@types/react-dom": "^18.2.4",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -21,7 +21,8 @@
     ],
     "scripts": {
         "build": "rm -rf dist && tsc",
-        "prepublishOnly": "npm run build"
+        "prepublishOnly": "npm run build",
+        "version": "npm pkg set dependencies.laravel-precognition=$npm_package_version"
     },
     "engines": {
         "node": ">=14"
@@ -30,7 +31,7 @@
         "react": "^18.0.0"
     },
     "dependencies": {
-        "laravel-precognition": "^0.3.0",
+        "laravel-precognition": "0.3.1",
         "lodash.clonedeep": "^4.5.0",
         "lodash.get": "^4.4.2",
         "lodash.set": "^4.3.2"

--- a/packages/vue-inertia/package.json
+++ b/packages/vue-inertia/package.json
@@ -23,7 +23,8 @@
     "scripts": {
         "build": "rm -rf dist && tsc",
         "prepublishOnly": "npm run build",
-        "test": "vitest run"
+        "test": "vitest run",
+        "version": "npm pkg set dependencies.laravel-precognition=$npm_package_version && npm pkg set dependencies.laravel-precognition-vue=$npm_package_version"
     },
     "engines": {
         "node": ">=14"
@@ -32,8 +33,8 @@
         "@inertiajs/vue3": "^1.0.0"
     },
     "dependencies": {
-        "laravel-precognition": "^0.3.0",
-        "laravel-precognition-vue": "^0.3.0"
+        "laravel-precognition": "0.3.1",
+        "laravel-precognition-vue": "0.3.1"
     },
     "devDependencies": {
         "typescript": "^5.0.0",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -21,7 +21,8 @@
     ],
     "scripts": {
         "build": "rm -rf dist && tsc",
-        "prepublishOnly": "npm run build"
+        "prepublishOnly": "npm run build",
+        "version": "npm pkg set dependencies.laravel-precognition=$npm_package_version"
     },
     "engines": {
         "node": ">=14"
@@ -30,7 +31,7 @@
         "vue": "^3.0.0"
     },
     "dependencies": {
-        "laravel-precognition": "^0.3.0",
+        "laravel-precognition": "0.3.1",
         "lodash.clonedeep": "^4.5.0",
         "lodash.get": "^4.4.2",
         "lodash.set": "^4.3.2"


### PR DESCRIPTION
- Ensure that explicit versions are used - rather than a range constraint.
- Introduce an executable `bin/release` script that will assist with bumping dependency version of the subpackages and versioning them at the same time.

We need this script because as the subpackages depend on each other. For example, the `precog-vue` package depends on the "core" package. When we version the vue package we need to bump the core version in the dependency list of the vue package.

Unfortunately, `npm` does not currently respect the order of the workspaces `"packages"` when versioning, so we cannot use the native `preversion` / `version` hooks to perform this work.

The script currently only does the work we would previously do when running `npm version patch`. We still need to manually publish. The script could be augmented to include this if it was useful.