### PR TITLE
[0.3.x] Fix array filtering of files

### DIFF
--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -321,7 +321,7 @@ const forgetFiles = (data: Record<string, unknown>): Record<string, unknown> => 
         }
 
         if (Array.isArray(value)) {
-            newData[name] = value.filter(isFile)
+            newData[name] = value.filter((value) => !isFile(value))
 
             return
         }

--- a/packages/core/tests/validator.test.js
+++ b/packages/core/tests/validator.test.js
@@ -224,3 +224,68 @@ it('is valid after field has changed and successful validation has triggered', a
     expect(requestMade).toBe(true)
     expect(validator.valid()).toEqual(['name'])
 })
+
+it('filters out files', () => {
+    let config
+    axios.request.mockImplementationOnce((c) => {
+        config = c
+        return Promise.resolve({ headers: { precognition: 'true' } })
+    })
+    const validator = createValidator((client) => client.post('/foo', {
+        name: 'Tim',
+        email: null,
+        fruits: [
+            'apple',
+            'banana',
+            new Blob([], { type: 'image/png' }),
+        ],
+        avatar: new Blob([], { type: 'image/png' }),
+        nested: {
+            name: 'Tim',
+            email: null,
+            fruits: [
+                'apple',
+                'banana',
+                new Blob([], { type: 'image/png' }),
+            ],
+            avatar: new Blob([], { type: 'image/png' }),
+            nested: {
+                name: 'Tim',
+                email: null,
+                fruits: [
+                    'apple',
+                    'banana',
+                    new Blob([], { type: 'image/png' }),
+                ],
+                avatar: new Blob([], { type: 'image/png' }),
+            }
+        }
+    }))
+
+    validator.validate('text', 'Tim')
+
+    expect(config.data).toEqual({
+        name: 'Tim',
+        email: null,
+        fruits: [
+            'apple',
+            'banana',
+        ],
+        nested: {
+            name: 'Tim',
+            email: null,
+            fruits: [
+                'apple',
+                'banana',
+            ],
+            nested: {
+                name: 'Tim',
+                email: null,
+                fruits: [
+                    'apple',
+                    'banana',
+                ],
+            }
+        }
+    })
+})


### PR DESCRIPTION
Currently, the file filtering applied to arrays in in reverse. It keeps everything except files. fixes #11