### PR TITLE
[0.3.x] Ensure marked as valid once response returns

### DIFF
--- a/packages/alpine/src/index.ts
+++ b/packages/alpine/src/index.ts
@@ -40,14 +40,13 @@ export default function (Alpine: TAlpine) {
             .on('validatingChanged', () => {
                 form.validating = validator.validating()
             })
-            .on('touchedChanged', () => {
+            .on('validatedChanged', () => {
                 state.valid = validator.valid()
-
+            })
+            .on('touchedChanged', () => {
                 state.touched = validator.touched()
             })
             .on('errorsChanged', () => {
-                state.valid = validator.valid()
-
                 form.hasErrors = validator.hasErrors()
 
                 form.errors = toSimpleValidationErrors(validator.errors())

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -175,7 +175,7 @@ const isNotServerGeneratedError = (error: unknown): boolean => {
  * Resolve the handler for the given HTTP response status.
  */
 const resolveStatusHandler = (config: Config, code: number): StatusHandler => {
-    const fallback: StatusHandler = (response) => response;
+    const fallback: StatusHandler = (response) => response
 
     const generalHandler: StatusHandler = code >= 200 && code < 300
         ? (config.onSuccess ?? fallback)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -12,6 +12,7 @@ export type Config = AxiosRequestConfig&{
     fingerprint?: string|null,
     onBefore?: () => boolean|undefined,
     onStart?: () => void,
+    onSuccess?: (response: AxiosResponse) => unknown,
     onPrecognitionSuccess?: (response: AxiosResponse) => unknown,
     onValidationError?: StatusHandler,
     onUnauthorized?: StatusHandler,
@@ -64,6 +65,7 @@ export interface ValidatorListeners {
     errorsChanged: Array<() => void>,
     validatingChanged: Array<() => void>,
     touchedChanged: Array<() => void>,
+    validatedChanged: Array<() => void>,
 }
 
 export type RequestMethod = 'get'|'post'|'patch'|'put'|'delete'

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -158,7 +158,7 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
                     ? config.onValidationError(response, axiosError)
                     : Promise.reject(axiosError)
             },
-            onSuccess: (response) => {
+            onSuccess: () => {
                 setValidated([...validated, ...validate])
             },
             onPrecognitionSuccess: (response) => {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -77,15 +77,14 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
             .on('validatingChanged', () => {
                 setValidating(validator.current!.validating())
             })
+            .on('validatedChanged', () => {
+                setValid(validator.current!.valid())
+            })
             .on('touchedChanged', () => {
                 setTouched(validator.current!.touched())
-
-                setValid(validator.current!.valid())
             })
             .on('errorsChanged', () => {
                 setHasErrors(validator.current!.hasErrors())
-
-                setValid(validator.current!.valid())
 
                 // @ts-expect-error
                 setErrors(toSimpleValidationErrors(validator.current!.errors()))

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -37,18 +37,16 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
         .on('validatingChanged', () => {
             form.validating = validator.validating()
         })
-        .on('touchedChanged', () => {
-            // @ts-expect-error
-            touched.value = validator.touched()
-
+        .on('validatedChanged', () => {
             // @ts-expect-error
             valid.value = validator.valid()
         })
+        .on('touchedChanged', () => {
+            // @ts-expect-error
+            touched.value = validator.touched()
+        })
         .on('errorsChanged', () => {
             form.hasErrors = validator.hasErrors()
-
-            // @ts-expect-error
-            valid.value = validator.valid()
 
             // @ts-expect-error
             form.errors = toSimpleValidationErrors(validator.errors())


### PR DESCRIPTION
Fields that have been "touched" are marked as "valid" when a validation request is in flight, if they have not yet been validated.

This fixes that issue and ensures that we only mark fields as valid once the response has returned and is:

1. Successful: 200 -> 299 status
2. Validation error: 422

Fixes https://github.com/laravel/precognition/issues/18