### PR TITLE
[0.3.x] Fix react-inertia setError bug

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -31,22 +31,22 @@ export const client: Client = {
     patch: (url, data = {}, config = {}) => request(mergeConfig('patch', url, data, config)),
     put: (url, data = {}, config = {}) => request(mergeConfig('put', url, data, config)),
     delete: (url, data = {}, config = {}) => request(mergeConfig('delete', url, data, config)),
-    use(client) {
-        axiosClient = client
+    use(axios) {
+        axiosClient = axios
 
-        return this
+        return client
     },
     fingerprintRequestsUsing(callback) {
         requestFingerprintResolver = callback === null
             ? () => null
             : callback
 
-        return this
+        return client
     },
     determineSuccessUsing(callback) {
         successResolver = callback
 
-        return this
+        return client
     },
 }
 

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -111,8 +111,6 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
         validator.cancel()
 
         validator = createValidator()
-
-        return this
     }
 
     /**
@@ -233,12 +231,12 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
     /**
      * The form validator instance.
      */
-    return {
+    const form: TValidator = {
         touched: () => touched,
         validate(input, value) {
             validate(input, value)
 
-            return this
+            return form
         },
         validating: () => validating,
         valid,
@@ -247,12 +245,12 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
         setErrors(value) {
             setErrors(value)
 
-            return this
+            return form
         },
         forgetError(name) {
             forgetError(name)
 
-            return this
+            return form
         },
         reset(...names) {
             if (names.length === 0) {
@@ -271,24 +269,26 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
                 setTouched(newTouched)
             }
 
-            return this
+            return form
         },
         setTimeout(value) {
             setDebounceTimeout(value)
 
-            return this
+            return form
         },
         on(event, callback) {
             listeners[event].push(callback)
 
-            return this
+            return form
         },
         validateFiles() {
             validateFiles = true
 
-            return this
+            return form
         },
     }
+
+    return form
 }
 
 /**

--- a/packages/react-inertia/src/index.ts
+++ b/packages/react-inertia/src/index.ts
@@ -60,7 +60,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
     /**
      * Patch the form.
      */
-    return Object.assign(inertiaForm, {
+    const form = Object.assign(inertiaForm, {
         validating: precognitiveForm.validating,
         touched: precognitiveForm.touched,
         valid: precognitiveForm.valid,
@@ -70,7 +70,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
 
             precognitiveForm.setData(key, value)
 
-            return this
+            return form
         },
         clearErrors(...names: string[]) {
             inertiaClearErrors(...names)
@@ -81,7 +81,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
                 names.forEach(precognitiveForm.forgetError)
             }
 
-            return this
+            return form
         },
         reset(...names: string[]) {
             inertiaReset(...names)
@@ -92,39 +92,39 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
             // @ts-expect-error
             precognitiveForm.setErrors(errors)
 
-            return this
+            return form
         },
         setError(key: any, value?: any) {
-            precognitiveForm.setErrors({
+            form.setErrors({
                 ...inertiaForm.errors,
                 ...typeof value === 'undefined'
                     ? key
                     : { [key]: value },
             })
 
-            return this
+            return form
         },
         forgetError(name: string|NamedInputEvent) {
             precognitiveForm.forgetError(name)
 
-            return this
+            return form
         },
         validate(name: string|NamedInputEvent) {
             precognitiveForm.setData(inertiaForm.data)
 
             precognitiveForm.validate(name)
 
-            return this
+            return form
         },
         setValidationTimeout(duration: number) {
             precognitiveForm.setValidationTimeout(duration)
 
-            return this
+            return form
         },
         validateFiles() {
             precognitiveForm.validateFiles()
 
-            return this
+            return form
         },
         submit(submitMethod: RequestMethod|Config = {}, submitUrl?: string, submitOptions?: any): void {
             const isPatchedCall = typeof submitMethod !== 'string'
@@ -154,4 +154,6 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
         },
         validator: precognitiveForm.validator,
     })
+
+    return form
 }

--- a/packages/react-inertia/src/index.ts
+++ b/packages/react-inertia/src/index.ts
@@ -95,7 +95,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
             return this
         },
         setError(key: any, value?: any) {
-            this.setErrors({
+            precognitiveForm.setErrors({
                 ...inertiaForm.errors,
                 ...typeof value === 'undefined'
                     ? key

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -116,7 +116,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
     /**
      * The form instance.
      */
-    return {
+    const form: Form<Data> = {
         data,
         setData(key, value) {
             if (typeof key === 'object') {
@@ -131,7 +131,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
                 setData(payload.current)
             }
 
-            return this
+            return form
         },
         touched(name) {
             return touched.includes(name)
@@ -142,7 +142,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
 
             validator.current!.validate(name, get(payload.current, name))
 
-            return this
+            return form
         },
         validating,
         valid(name) {
@@ -157,13 +157,13 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
             // @ts-expect-error
             validator.current!.setErrors(errors)
 
-            return this
+            return form
         },
         forgetError(name) {
             // @ts-expect-error
             validator.current!.forgetError(name)
 
-            return this
+            return form
         },
         reset(...names) {
             const original = cloneDeep(originalData.current)!
@@ -181,12 +181,12 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
             // @ts-expect-error
             validator.current!.reset(...names)
 
-            return this
+            return form
         },
         setValidationTimeout(duration) {
             validator.current!.setTimeout(duration)
 
-            return this
+            return form
         },
         processing,
         async submit(config = {}) {
@@ -195,10 +195,12 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
         validateFiles() {
             validator.current!.validateFiles()
 
-            return this
+            return form
         },
         validator() {
             return validator.current!
         },
     }
+
+    return form
 }

--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -48,7 +48,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
     /**
      * Patch the form.
      */
-    return Object.assign(inertiaForm, {
+    const form = Object.assign(inertiaForm, {
         validating: precognitiveForm.validating,
         touched: precognitiveForm.touched,
         valid: precognitiveForm.valid,
@@ -62,7 +62,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
                 names.forEach(precognitiveForm.forgetError)
             }
 
-            return this
+            return form
         },
         reset(...names: string[]) {
             inertiaReset(...names)
@@ -73,39 +73,39 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
             // @ts-expect-error
             precognitiveForm.setErrors(errors)
 
-            return this
+            return form
         },
         forgetError(name: string|NamedInputEvent) {
             precognitiveForm.forgetError(name)
 
-            return this
+            return form
         },
         setError(key: any, value?: any) {
-            this.setErrors({
+            form.setErrors({
                 ...inertiaForm.errors,
                 ...typeof value === 'undefined'
                     ? key
                     : { [key]: value },
             })
 
-            return this
+            return form
         },
         validate(name: string|NamedInputEvent) {
             precognitiveForm.setData(inertiaForm.data())
 
             precognitiveForm.validate(name)
 
-            return this
+            return form
         },
         setValidationTimeout(duration: number) {
             precognitiveForm.setValidationTimeout(duration)
 
-            return this
+            return form
         },
         validateFiles() {
             precognitiveForm.validateFiles()
 
-            return this
+            return form
         },
         submit(submitMethod: RequestMethod|Config = {}, submitUrl?: string, submitOptions?: any): void {
             const isPatchedCall = typeof submitMethod !== 'string'
@@ -135,4 +135,6 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
         },
         validator: precognitiveForm.validator,
     })
+
+    return form
 }

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -77,7 +77,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
     /**
      * Create a new form instance.
      */
-    const createForm = (): Data&Form<Data> => ({
+    const form: Data&Form<Data> = {
         ...cloneDeep(originalData),
         data() {
             const data = cloneDeep(toRaw(form))
@@ -89,7 +89,8 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
         },
         setData(data: Record<string, unknown>) {
             Object.keys(data).forEach(input => {
-                this[input] = data[input]
+                // @ts-expect-error
+                form[input] = data[input]
             })
 
             return form
@@ -102,7 +103,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
             // @ts-expect-error
             name = resolveName(name)
 
-            validator.validate(name, get(this.data(), name))
+            validator.validate(name, get(form.data(), name))
 
             return form
         },
@@ -160,12 +161,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
         validator() {
             return validator
         },
-    })
+    }
 
-    /**
-     * The form instance.
-     */
-    const form = reactive(createForm()) as Data&Form<Data>
-
-    return form
+    return reactive(form) as Data&Form<Data>
 }

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -77,7 +77,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
     /**
      * Create a new form instance.
      */
-    const form: Data&Form<Data> = {
+    let form: Data&Form<Data> = {
         ...cloneDeep(originalData),
         data() {
             const data = cloneDeep(toRaw(form))
@@ -163,5 +163,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
         },
     }
 
-    return reactive(form) as Data&Form<Data>
+    form = reactive(form) as Data&Form<Data>
+
+    return form
 }


### PR DESCRIPTION
<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

It seems that we cannot use the `setError` method of laravel-precognition-react-inertia in the current implementation.

Upon inspecting the internals, it appears that the `setError` method uses `setErrors` internally.
However, due to a mistake with `this` variable, attempting to use `setError` was resulting in it being interpreted as a non-existent property and couldn't be used. 
I have made the necessary corrections to address this issue, so `setError` should now be properly usable.
