### PR TITLE
[0.3.x] Allow config to override initial values

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,3 @@
-export { client } from './client'
+export { client, resolveUrl, resolveMethod } from './client'
 export { createValidator, toSimpleValidationErrors, resolveName } from './validator'
 export * from './types'

--- a/packages/core/tests/client.test.js
+++ b/packages/core/tests/client.test.js
@@ -513,3 +513,132 @@ it('does not revaldata when data is unchanged', async () => {
     expect(requests).toBe(2)
     vi.advanceTimersByTime(1500)
 })
+
+it('overrides request method url with config url', async () => {
+    expect.assertions(5)
+
+    let config
+    axios.request.mockImplementation((c) => {
+        config = c
+        return Promise.resolve({ headers: { precognition: 'true' }, status: 204, data: 'data' })
+    })
+
+    await client.get('https://laravel.com', {}, {
+        url: 'https://forge.laravel.com',
+    })
+    expect(config.url).toBe('https://forge.laravel.com')
+
+    await client.post('https://laravel.com', {}, {
+        url: 'https://forge.laravel.com',
+    })
+    expect(config.url).toBe('https://forge.laravel.com')
+
+    await client.patch('https://laravel.com', {}, {
+        url: 'https://forge.laravel.com',
+    })
+    expect(config.url).toBe('https://forge.laravel.com')
+
+    await client.put('https://laravel.com', {}, {
+        url: 'https://forge.laravel.com',
+    })
+    expect(config.url).toBe('https://forge.laravel.com')
+
+    await client.delete('https://laravel.com', {}, {
+        url: 'https://forge.laravel.com',
+    })
+    expect(config.url).toBe('https://forge.laravel.com')
+})
+
+it('overrides the request data with the config data', async () => {
+    expect.assertions(5)
+
+    let config
+    axios.request.mockImplementation((c) => {
+        config = c
+        return Promise.resolve({ headers: { precognition: 'true' }, status: 204, data: 'data' })
+    })
+
+    await client.get('https://laravel.com', { expected: false }, {
+        data: { expected: true }
+    })
+    expect(config.data).toEqual({ expected: true})
+
+    await client.post('https://laravel.com', { expected: false }, {
+        data: { expected: true }
+    })
+    expect(config.data).toEqual({ expected: true})
+
+    await client.patch('https://laravel.com', { expected: false }, {
+        data: { expected: true }
+    })
+    expect(config.data).toEqual({ expected: true})
+
+    await client.put('https://laravel.com', { expected: false }, {
+        data: { expected: true }
+    })
+    expect(config.data).toEqual({ expected: true})
+
+    await client.delete('https://laravel.com', { expected: false }, {
+        data: { expected: true }
+    })
+    expect(config.data).toEqual({ expected: true})
+})
+
+it('merges request data with config data', async () => {
+    expect.assertions(7)
+
+    let config
+    axios.request.mockImplementation((c) => {
+        config = c
+        return Promise.resolve({ headers: { precognition: 'true' }, status: 204, data: 'data' })
+    })
+
+    await client.get('https://laravel.com', { request: true }, {
+        data: { config: true }
+    })
+    expect(config.data).toEqual({ config: true })
+    expect(config.params).toEqual({ request: true })
+
+    await client.post('https://laravel.com', { request: true }, {
+        data: { config: true }
+    })
+    expect(config.data).toEqual({ request: true, config: true })
+
+    await client.patch('https://laravel.com', { request: true }, {
+        data: { config: true }
+    })
+    expect(config.data).toEqual({ request: true, config: true })
+
+    await client.put('https://laravel.com', { request: true }, {
+        data: { config: true }
+    })
+    expect(config.data).toEqual({ request: true, config: true })
+
+    await client.delete('https://laravel.com', { request: true }, {
+        data: { config: true }
+    })
+    expect(config.data).toEqual({ config: true })
+    expect(config.params).toEqual({ request: true })
+})
+
+it('merges request data with config params for get and delete requests', async () => {
+    expect.assertions(4)
+
+    let config
+    axios.request.mockImplementation((c) => {
+        config = c
+        return Promise.resolve({ headers: { precognition: 'true' }, status: 204, data: 'data' })
+    })
+
+    await client.get('https://laravel.com', { data: true }, {
+        params: { param: true }
+    })
+    expect(config.params).toEqual({ data: true, param: true })
+    expect(config.data).toBeUndefined()
+
+    await client.delete('https://laravel.com', { data: true }, {
+        params: { param: true }
+    })
+    expect(config.params).toEqual({ data: true, param: true })
+    expect(config.data).toBeUndefined()
+})

--- a/packages/core/tests/validator.test.js
+++ b/packages/core/tests/validator.test.js
@@ -375,3 +375,34 @@ it('does mark fields as validated on success status', async () => {
     expect(validator.valid()).toEqual(['app'])
     expect(onValidatedChangedCalledTimes).toEqual(1)
 })
+
+it('can provide a callback for the url', async () => {
+    expect.assertions(4)
+
+    let config = null
+    let url = null
+    let data
+    let requests = 0
+    axios.request.mockImplementation((c) => {
+        config = c
+        requests++
+        return Promise.resolve({ status: 201, headers: { precognition: 'true' } })
+    })
+    const validator = createValidator((client) => client.post(() => url, data), {})
+
+    url = 'https://foo'
+    data = { name: 'Tim' }
+    validator.validate('name', 'Tim')
+    vi.advanceTimersByTime(1500)
+
+    expect(requests).toBe(1)
+    expect(config.url).toBe('https://foo')
+
+    url = 'https://bar'
+    data = { name: 'Taylor' }
+    validator.validate('name', 'Taylor')
+    vi.advanceTimersByTime(1500)
+
+    expect(requests).toBe(2)
+    expect(config.url).toBe('https://bar')
+})

--- a/packages/core/tests/validator.test.js
+++ b/packages/core/tests/validator.test.js
@@ -375,34 +375,3 @@ it('does mark fields as validated on success status', async () => {
     expect(validator.valid()).toEqual(['app'])
     expect(onValidatedChangedCalledTimes).toEqual(1)
 })
-
-it('can provide a callback for the url', async () => {
-    expect.assertions(4)
-
-    let config = null
-    let url = null
-    let data
-    let requests = 0
-    axios.request.mockImplementation((c) => {
-        config = c
-        requests++
-        return Promise.resolve({ status: 201, headers: { precognition: 'true' } })
-    })
-    const validator = createValidator((client) => client.post(() => url, data), {})
-
-    url = 'https://foo'
-    data = { name: 'Tim' }
-    validator.validate('name', 'Tim')
-    vi.advanceTimersByTime(1500)
-
-    expect(requests).toBe(1)
-    expect(config.url).toBe('https://foo')
-
-    url = 'https://bar'
-    data = { name: 'Taylor' }
-    validator.validate('name', 'Taylor')
-    vi.advanceTimersByTime(1500)
-
-    expect(requests).toBe(2)
-    expect(config.url).toBe('https://bar')
-})

--- a/packages/react-inertia/src/index.ts
+++ b/packages/react-inertia/src/index.ts
@@ -1,12 +1,9 @@
-import { Config, NamedInputEvent, RequestMethod, SimpleValidationErrors, toSimpleValidationErrors, ValidationConfig, ValidationErrors } from 'laravel-precognition'
+import { Config, NamedInputEvent, RequestMethod, SimpleValidationErrors, toSimpleValidationErrors, ValidationConfig, ValidationErrors, resolveUrl, resolveMethod } from 'laravel-precognition'
 import { useForm as usePrecognitiveForm } from 'laravel-precognition-react'
 import { useForm as useInertiaForm } from '@inertiajs/react'
 import { useRef } from 'react'
 
-export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod, url: string, inputs: Data, config: ValidationConfig = {}): any => {
-    // @ts-expect-error
-    method = method.toLowerCase()
-
+export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): any => {
     const booted = useRef<boolean>(false)
 
     /**
@@ -132,27 +129,28 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
         submit(submitMethod: RequestMethod|Config = {}, submitUrl?: string, submitOptions?: any): void {
             const isPatchedCall = typeof submitMethod !== 'string'
 
-            const userOptions = isPatchedCall
+            submitOptions = isPatchedCall
                 ? submitMethod
                 : submitOptions
 
-            const options = {
-                ...userOptions,
+            submitUrl = isPatchedCall
+                ? resolveUrl(url)
+                : submitUrl!
+
+            submitMethod = isPatchedCall
+                ? resolveMethod(method)
+                : submitMethod as RequestMethod
+
+            inertiaSubmit(submitMethod, submitUrl, {
+                ...submitOptions,
                 onError: (errors: SimpleValidationErrors): any => {
                     precognitiveForm.validator().setErrors(errors)
 
-                    if (userOptions.onError) {
-                        return userOptions.onError(errors)
+                    if (submitOptions.onError) {
+                        return submitOptions.onError(errors)
                     }
                 },
-            }
-
-            inertiaSubmit(
-                isPatchedCall ? method : submitMethod,
-                // @ts-expect-error
-                (isPatchedCall ? url : submitUrl),
-                options
-            )
+            })
         },
         validator: precognitiveForm.validator,
     })

--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -120,7 +120,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
 
             submitMethod = isPatchedCall
                 ? resolveMethod(method)
-                : (submitMethod as RequestMethod)
+                : submitMethod as RequestMethod
 
             inertiaSubmit(submitMethod, submitUrl, {
                 ...submitOptions,

--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -1,11 +1,8 @@
-import { Config, NamedInputEvent, RequestMethod, SimpleValidationErrors, toSimpleValidationErrors, ValidationConfig, ValidationErrors } from 'laravel-precognition'
+import { Config, NamedInputEvent, RequestMethod, SimpleValidationErrors, toSimpleValidationErrors, ValidationConfig, ValidationErrors, resolveUrl, resolveMethod } from 'laravel-precognition'
 import { useForm as usePrecognitiveForm } from 'laravel-precognition-vue'
 import { useForm as useInertiaForm } from '@inertiajs/vue3'
 
-export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod, url: string, inputs: Data, config: ValidationConfig = {}): any => {
-    // @ts-expect-error
-    method = method.toLowerCase()
-
+export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): any => {
     /**
      * The Inertia form.
      */
@@ -113,27 +110,28 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
         submit(submitMethod: RequestMethod|Config = {}, submitUrl?: string, submitOptions?: any): void {
             const isPatchedCall = typeof submitMethod !== 'string'
 
-            const userOptions = isPatchedCall
+            submitOptions = isPatchedCall
                 ? submitMethod
                 : submitOptions
 
-            const options = {
-                ...userOptions,
+            submitUrl = isPatchedCall
+                ? resolveUrl(url)
+                : submitUrl!
+
+            submitMethod = isPatchedCall
+                ? resolveMethod(method)
+                : (submitMethod as RequestMethod)
+
+            inertiaSubmit(submitMethod, submitUrl, {
+                ...submitOptions,
                 onError: (errors: SimpleValidationErrors): any => {
                     precognitiveForm.validator().setErrors(errors)
 
-                    if (userOptions.onError) {
-                        return userOptions.onError(errors)
+                    if (submitOptions.onError) {
+                        return submitOptions.onError(errors)
                     }
                 },
-            }
-
-            inertiaSubmit(
-                isPatchedCall ? method : submitMethod,
-                // @ts-expect-error
-                (isPatchedCall ? url : submitUrl),
-                options
-            )
+            })
         },
         validator: precognitiveForm.validator,
     })


### PR DESCRIPTION
This PR allows configuration values to override (or merge with) the initial data provided when creating the validator. This is useful for validation if you wish to change these values just for the "submission" of the form itself, via `form.submit(OPTIONS)`

Also, it also allows the url and method to be specified as a callback, which allows the them to be changed after the form as been created...

```js
let endpoint = null;

form = useForm('post', () => endpoint, {});

endpoint = 'https://first.com';
form.validate('name');

endpoint = 'https://second.com';
form.validate('name');
```

This can be useful if your form url is dynamic and determined by the current state of the application.

Fixes https://github.com/laravel/precognition/issues/20