### PR TITLE
[0.3.x] Expose the client / axios instance

### DIFF
--- a/packages/alpine/src/index.ts
+++ b/packages/alpine/src/index.ts
@@ -5,6 +5,8 @@ import get from 'lodash.get'
 import set from 'lodash.set'
 import { Form } from './types'
 
+export { client }
+
 export default function (Alpine: TAlpine) {
     Alpine.magic('form', (el) => <Data extends Record<string, unknown>>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): Data&Form<Data> => {
         syncWithDom(el, resolveMethod(method), resolveUrl(url))

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -5,7 +5,7 @@ import { Config, Client, RequestFingerprintResolver, StatusHandler, SuccessResol
 /**
  * The configured axios client.
  */
-let axiosClient: AxiosInstance = Axios
+let axiosClient: AxiosInstance = Axios.create()
 
 /**
  * The request fingerprint resolver.
@@ -35,6 +35,9 @@ export const client: Client = {
         axiosClient = client
 
         return this
+    },
+    axios() {
+        return axiosClient
     },
     fingerprintRequestsUsing(callback) {
         requestFingerprintResolver = callback === null

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -44,6 +44,7 @@ export interface Client {
     use(axios: AxiosInstance): Client,
     fingerprintRequestsUsing(callback: RequestFingerprintResolver|null): Client,
     determineSuccessUsing(callback: SuccessResolver): Client,
+    axios(): AxiosInstance,
 }
 
 export interface Validator {

--- a/packages/core/tests/client.test.js
+++ b/packages/core/tests/client.test.js
@@ -5,6 +5,7 @@ import { createValidator } from '../src/validator'
 
 beforeEach(() => {
     vi.mock('axios')
+    client.use(axios)
     vi.useFakeTimers()
 })
 

--- a/packages/core/tests/validator.test.js
+++ b/packages/core/tests/validator.test.js
@@ -1,10 +1,12 @@
 import { it, vi, expect, beforeEach, afterEach } from 'vitest'
 import axios from 'axios'
+import { client } from '../src/client'
 import { createValidator } from '../src/validator'
 
 beforeEach(() => {
     vi.mock('axios')
     vi.useFakeTimers()
+    client.use(axios)
 })
 
 afterEach(() => {

--- a/packages/react-inertia/src/index.ts
+++ b/packages/react-inertia/src/index.ts
@@ -1,7 +1,9 @@
 import { Config, NamedInputEvent, RequestMethod, SimpleValidationErrors, toSimpleValidationErrors, ValidationConfig, ValidationErrors, resolveUrl, resolveMethod } from 'laravel-precognition'
-import { useForm as usePrecognitiveForm } from 'laravel-precognition-react'
+import { useForm as usePrecognitiveForm, client } from 'laravel-precognition-react'
 import { useForm as useInertiaForm } from '@inertiajs/react'
 import { useRef } from 'react'
+
+export { client }
 
 export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): any => {
     const booted = useRef<boolean>(false)

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -5,6 +5,8 @@ import set from 'lodash.set'
 import { useRef, useState } from 'react'
 import { Form } from './types'
 
+export { client }
+
 export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), input: Data, config: ValidationConfig = {}): Form<Data> => {
     /**
      * The original data.

--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -1,6 +1,8 @@
 import { Config, NamedInputEvent, RequestMethod, SimpleValidationErrors, toSimpleValidationErrors, ValidationConfig, ValidationErrors, resolveUrl, resolveMethod } from 'laravel-precognition'
-import { useForm as usePrecognitiveForm } from 'laravel-precognition-vue'
+import { useForm as usePrecognitiveForm, client } from 'laravel-precognition-vue'
 import { useForm as useInertiaForm } from '@inertiajs/vue3'
+
+export { client }
 
 export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): any => {
     /**

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -6,6 +6,8 @@ import get from 'lodash.get'
 import { resolveName } from 'laravel-precognition'
 import set from 'lodash.set'
 
+export { client }
+
 export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): Data&Form<Data> => {
     /**
      * The original data.


### PR DESCRIPTION
This PR exposes the axios client across all libraries to enable easy configuration of all precognition request.

```js
import { client } from 'laravel-precognition-LIBRARY'

client.axios().defaults.headers.common['Authorization'] = AUTH_TOKEN;
```


fixes #21

It is already possible to pass a pre-configured axios instance.

```js
import { client } from 'laravel-precognition-LIBRARY'

// ...

client.use(myAxiosInstace)
```