### PR TITLE
[0.3.x] Allow fields to be manually touched

### DIFF
--- a/packages/alpine/src/index.ts
+++ b/packages/alpine/src/index.ts
@@ -98,9 +98,13 @@ export default function (Alpine: TAlpine) {
                 return form
             },
             validate(name) {
-                name = resolveName(name)
+                if (typeof name === 'undefined') {
+                    validator.validate()
+                } else {
+                    name = resolveName(name)
 
-                validator.validate(name, get(form.data(), name))
+                    validator.validate(name, get(form.data(), name))
+                }
 
                 return form
             },

--- a/packages/alpine/src/index.ts
+++ b/packages/alpine/src/index.ts
@@ -92,6 +92,11 @@ export default function (Alpine: TAlpine) {
             touched(name) {
                 return state.touched.includes(name)
             },
+            touch(name) {
+                validator.touch(name)
+
+                return form
+            },
             validate(name) {
                 name = resolveName(name)
 

--- a/packages/alpine/src/types.ts
+++ b/packages/alpine/src/types.ts
@@ -4,6 +4,7 @@ export interface Form<Data extends Record<string, unknown>> {
     processing: boolean,
     validating: boolean,
     touched(name: string): boolean,
+    touch(name: string|NamedInputEvent|Array<string>): Data&Form<Data>,
     data(): Data,
     errors: Record<string, string>,
     hasErrors: boolean,

--- a/packages/alpine/src/types.ts
+++ b/packages/alpine/src/types.ts
@@ -10,7 +10,7 @@ export interface Form<Data extends Record<string, unknown>> {
     hasErrors: boolean,
     valid(name: string): boolean,
     invalid(name: string): boolean,
-    validate(name: string|NamedInputEvent): Data&Form<Data>,
+    validate(name?: string|NamedInputEvent): Data&Form<Data>,
     setErrors(errors: SimpleValidationErrors|ValidationErrors): Data&Form<Data>
     forgetError(name: string|NamedInputEvent): Data&Form<Data>
     setValidationTimeout(duration: number): Data&Form<Data>,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -50,7 +50,7 @@ export interface Client {
 
 export interface Validator {
     touched(): Array<string>,
-    validate(input: string|NamedInputEvent, value: unknown): Validator,
+    validate(input?: string|NamedInputEvent, value?: unknown): Validator,
     touch(input: string|NamedInputEvent|Array<string>): Validator,
     validating(): boolean,
     valid(): Array<string>,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -25,6 +25,7 @@ export type Config = AxiosRequestConfig&{
 
 interface RevalidatePayload {
     data: Record<string, unknown>|null,
+    touched: Array<string>,
 }
 
 export type ValidationConfig = Config&{
@@ -50,6 +51,7 @@ export interface Client {
 export interface Validator {
     touched(): Array<string>,
     validate(input: string|NamedInputEvent, value: unknown): Validator,
+    touch(input: string|NamedInputEvent|Array<string>): Validator,
     validating(): boolean,
     valid(): Array<string>,
     errors(): ValidationErrors,

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -121,7 +121,7 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
     /**
      * The data currently being validated.
      */
-    let validatingData: Record<string, unknown> = {}
+    let validatingData: null|Record<string, unknown> = null
 
     /**
      * The old touched.
@@ -131,7 +131,7 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
     /**
      * The touched currently being validated.
      */
-    let validatingTouched: string[] = []
+    let validatingTouched: null|string[] = null
 
     /**
      * Create a debounced validation callback.
@@ -184,7 +184,7 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
             onBefore: () => {
                 const beforeValidationResult = (config.onBeforeValidation ?? ((previous, next) => {
                     return ! isequal(previous, next)
-                }))({ data, touched }, { data: oldData, touched: oldTouched })
+                }))({ data, touched }, { data: validatingData ?? oldData, touched: validatingTouched ?? oldTouched })
 
                 if (beforeValidationResult === false) {
                     return false
@@ -210,9 +210,11 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
             onFinish: () => {
                 setValidating(false)
 
-                oldTouched = validatingTouched
+                oldTouched = validatingTouched!
 
-                oldData = validatingData;
+                oldData = validatingData!
+
+                validatingTouched = validatingData = null;
 
                 (config.onFinish ?? (() => null))()
             },

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -184,7 +184,7 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
             onBefore: () => {
                 const beforeValidationResult = (config.onBeforeValidation ?? ((previous, next) => {
                     return ! isequal(previous, next)
-                }))({ data, touched }, { data: validatingData ?? oldData, touched: validatingTouched ?? oldTouched })
+                }))({ data, touched }, { data: oldData, touched: oldTouched })
 
                 if (beforeValidationResult === false) {
                     return false
@@ -224,7 +224,13 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
     /**
      * Validate the given input.
      */
-    const validate = (name: string|NamedInputEvent, value: unknown) => {
+    const validate = (name?: string|NamedInputEvent, value?: unknown) => {
+        if (typeof name === 'undefined') {
+            validator()
+
+            return
+        }
+
         if (isFile(value) && !validateFiles) {
             console.warn('Precognition file validation is not active. Call the "validateFiles" function on your form to enable it.')
 

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -119,6 +119,11 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
     let oldData = initialData
 
     /**
+     * The old touched.
+     */
+    let oldTouched = touched
+
+    /**
      * Create a debounced validation callback.
      */
     const createValidator = () => debounce(() => {
@@ -169,7 +174,7 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
             onBefore: () => {
                 const beforeValidationResult = (config.onBeforeValidation ?? ((newRequest, oldRequest) => {
                     return ! isequal(newRequest, oldRequest)
-                }))({ data }, { data: oldData })
+                }))({ data, touched }, { data: oldData, touched: oldTouched })
 
                 if (beforeValidationResult === false) {
                     return false
@@ -180,6 +185,8 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
                 if (beforeResult === false) {
                     return false
                 }
+
+                oldTouched = touched
 
                 oldData = data
 
@@ -235,6 +242,15 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
         touched: () => touched,
         validate(input, value) {
             validate(input, value)
+
+            return form
+        },
+        touch(input) {
+            const inputs = Array.isArray(input)
+                ? input
+                : [resolveName(input)]
+
+            setTouched([...touched, ...inputs])
 
             return form
         },

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -119,9 +119,19 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
     let oldData = initialData
 
     /**
+     * The data currently being validated.
+     */
+    let validatingData: Record<string, unknown> = {}
+
+    /**
      * The old touched.
      */
-    let oldTouched = touched
+    let oldTouched: string[] = []
+
+    /**
+     * The touched currently being validated.
+     */
+    let validatingTouched: string[] = []
 
     /**
      * Create a debounced validation callback.
@@ -172,8 +182,8 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
                     : response
             },
             onBefore: () => {
-                const beforeValidationResult = (config.onBeforeValidation ?? ((newRequest, oldRequest) => {
-                    return ! isequal(newRequest, oldRequest)
+                const beforeValidationResult = (config.onBeforeValidation ?? ((previous, next) => {
+                    return ! isequal(previous, next)
                 }))({ data, touched }, { data: oldData, touched: oldTouched })
 
                 if (beforeValidationResult === false) {
@@ -186,9 +196,9 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
                     return false
                 }
 
-                oldTouched = touched
+                validatingTouched = touched
 
-                oldData = data
+                validatingData = data
 
                 return true
             },
@@ -198,7 +208,11 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
                 (config.onStart ?? (() => null))()
             },
             onFinish: () => {
-                setValidating(false);
+                setValidating(false)
+
+                oldTouched = validatingTouched
+
+                oldData = validatingData;
 
                 (config.onFinish ?? (() => null))()
             },

--- a/packages/core/tests/client.test.js
+++ b/packages/core/tests/client.test.js
@@ -1,7 +1,6 @@
 import { it, vi, expect, beforeEach, afterEach } from 'vitest'
 import axios from 'axios'
 import { client } from '../src/index'
-import { createValidator } from '../src/validator'
 
 beforeEach(() => {
     vi.mock('axios')
@@ -453,66 +452,6 @@ it('does not create an abort controller when a cancelToken is provided', async (
     })
 
     expect(config.signal).toBeUndefined()
-})
-
-it('revaldata when validate is called', async () => {
-    expect.assertions(4)
-
-    let requests = 0
-    axios.request.mockImplementation(() => {
-        requests++
-
-        return Promise.resolve({ headers: { precognition: 'true' } })
-    })
-    let data
-    const validator = createValidator((client) => client.post('/foo', data))
-
-    expect(requests).toBe(0)
-
-    data = { name: 'Tim' }
-    validator.validate('name', 'Tim')
-    expect(requests).toBe(1)
-    vi.advanceTimersByTime(1500)
-
-    data = { name: 'Jess' }
-    validator.validate('name', 'Jess')
-    expect(requests).toBe(2)
-    vi.advanceTimersByTime(1500)
-
-    data = { name: 'Taylor' }
-    validator.validate('name', 'Taylor')
-    expect(requests).toBe(3)
-    vi.advanceTimersByTime(1500)
-})
-
-it('does not revaldata when data is unchanged', async () => {
-    expect.assertions(4)
-
-    let requests = 0
-    axios.request.mockImplementation(() => {
-        requests++
-
-        return Promise.resolve({ headers: { precognition: 'true' } })
-    })
-    let data = {}
-    const validator = createValidator((client) => client.post('/foo', data))
-
-    expect(requests).toBe(0)
-
-    data = { first: true }
-    validator.validate('name', true)
-    expect(requests).toBe(1)
-    vi.advanceTimersByTime(1500)
-
-    data = { first: true }
-    validator.validate('name', true)
-    expect(requests).toBe(1)
-    vi.advanceTimersByTime(1500)
-
-    data = { second: true }
-    validator.validate('name', true)
-    expect(requests).toBe(2)
-    vi.advanceTimersByTime(1500)
 })
 
 it('overrides request method url with config url', async () => {

--- a/packages/core/tests/validator.test.js
+++ b/packages/core/tests/validator.test.js
@@ -54,7 +54,7 @@ it('does not revalidate data when data is unchanged', async () => {
         return Promise.resolve({ headers: { precognition: 'true' } })
     })
     let data = {}
-    const validator = createValidator((client) => client.post('/foo', data), data)
+    const validator = createValidator((client) => client.post('/foo', data))
 
     expect(requests).toBe(0)
 
@@ -403,7 +403,7 @@ it('can make fields as touched', () => {
 })
 
 it('does not remember old data or touched until the response has returned', async () => {
-    expect.assertions(8)
+    expect.assertions(7)
 
     let requests = 0
     let resolvers = []

--- a/packages/core/tests/validator.test.js
+++ b/packages/core/tests/validator.test.js
@@ -378,7 +378,7 @@ it('does mark fields as validated on success status', async () => {
     expect(onValidatedChangedCalledTimes).toEqual(1)
 })
 
-it('can make fields as touched', () => {
+it('can mark fields as touched', () => {
     expect.assertions(3)
 
     let requests = 0

--- a/packages/core/tests/validator.test.js
+++ b/packages/core/tests/validator.test.js
@@ -65,7 +65,7 @@ it('does not revalidate data when data is unchanged', async () => {
 
     data = { first: true }
     validator.validate('name', true)
-    expect(requests).toBe(1) // fails
+    expect(requests).toBe(1)
     vi.advanceTimersByTime(1500)
 
     data = { second: true }
@@ -400,46 +400,4 @@ it('can make fields as touched', () => {
     expect(validator.touched()).toEqual(['name'])
     vi.advanceTimersByTime(2000)
     expect(requests).toBe(1)
-})
-
-it('does not remember old data or touched until the response has returned', async () => {
-    expect.assertions(7)
-
-    let requests = 0
-    let resolvers = []
-    let promises = []
-    let configs = []
-    axios.request.mockImplementation((c) => {
-        requests++
-        configs.push(c)
-
-        const promise = new Promise(resolve => {
-            resolvers.push(resolve)
-        })
-
-        promises.push(promise)
-
-        return promise
-    })
-    let data = { version: '10' }
-    const validator = createValidator((client) => client.post('/foo', data))
-
-    data = { app: 'Laravel' }
-    validator.validate('app', 'Laravel')
-    expect(requests).toBe(1)
-    expect(configs[0].onBefore()).toBe(true)
-    vi.advanceTimersByTime(2000)
-    expect(configs[0].onBefore()).toBe(true)
-
-    validator.touch('version')
-    validator.validate('app', 'Laravel')
-    expect(requests).toBe(2)
-    expect(configs[1].onBefore()).toBe(true)
-    vi.advanceTimersByTime(2000)
-    expect(configs[1].onBefore()).toBe(true)
-
-    resolvers[1]({ headers: { precognition: 'true' }, status: 204 })
-    await vi.runAllTimersAsync()
-
-    expect(configs[1].onBefore()).toBe(false)
 })

--- a/packages/core/tests/validator.test.js
+++ b/packages/core/tests/validator.test.js
@@ -60,16 +60,19 @@ it('does not revalidate data when data is unchanged', async () => {
 
     data = { first: true }
     validator.validate('name', true)
+    await vi.runAllTimersAsync()
     expect(requests).toBe(1)
     vi.advanceTimersByTime(1500)
 
     data = { first: true }
     validator.validate('name', true)
+    await vi.runAllTimersAsync()
     expect(requests).toBe(1)
     vi.advanceTimersByTime(1500)
 
     data = { second: true }
     validator.validate('name', true)
+    await vi.runAllTimersAsync()
     expect(requests).toBe(2)
     vi.advanceTimersByTime(1500)
 })
@@ -416,4 +419,20 @@ it('revalidates when touched changes', async () => {
     validator.validate('app', 'Laravel')
     vi.advanceTimersByTime(2000)
     expect(requests).toBe(2)
+})
+
+it('can validate without needing to specify a field', async () => {
+    expect.assertions(1)
+
+    let requests = 0
+    axios.request.mockImplementation(() => {
+        requests++
+
+        return Promise.resolve({ headers: { precognition: 'true' } })
+    })
+    let data = { name: 'Tim', framework: 'Laravel' }
+    const validator = createValidator((client) => client.post('/foo', data))
+
+    validator.touch(['name', 'framework']).validate()
+    expect(requests).toBe(1)
 })

--- a/packages/react-inertia/src/index.ts
+++ b/packages/react-inertia/src/index.ts
@@ -116,7 +116,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
 
             return form
         },
-        validate(name: string|NamedInputEvent) {
+        validate(name?: string|NamedInputEvent) {
             precognitiveForm.setData(inertiaForm.data)
 
             precognitiveForm.validate(name)

--- a/packages/react-inertia/src/index.ts
+++ b/packages/react-inertia/src/index.ts
@@ -65,6 +65,11 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
     const form = Object.assign(inertiaForm, {
         validating: precognitiveForm.validating,
         touched: precognitiveForm.touched,
+        touch(name: Array<string>|string|NamedInputEvent) {
+            precognitiveForm.touch(name)
+
+            return form
+        },
         valid: precognitiveForm.valid,
         invalid: precognitiveForm.invalid,
         setData(key: any, value?: any) {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -138,6 +138,11 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
         touched(name) {
             return touched.includes(name)
         },
+        touch(name) {
+            validator.current!.touch(name)
+
+            return form
+        },
         validate(name) {
             // @ts-expect-error
             name = resolveName(name)

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -144,10 +144,14 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
             return form
         },
         validate(name) {
-            // @ts-expect-error
-            name = resolveName(name)
+            if (typeof name === 'undefined') {
+                validator.current!.validate()
+            } else {
+                // @ts-expect-error
+                name = resolveName(name)
 
-            validator.current!.validate(name, get(payload.current, name))
+                validator.current!.validate(name, get(payload.current, name))
+            }
 
             return form
         },

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -11,7 +11,7 @@ export interface Form<Data extends Record<string, unknown>> {
     hasErrors: boolean,
     valid(name: keyof Data): boolean,
     invalid(name: keyof Data): boolean,
-    validate(name: keyof Data|NamedInputEvent): Form<Data>,
+    validate(name?: keyof Data|NamedInputEvent): Form<Data>,
     setErrors(errors: Partial<Record<keyof Data, string|string[]>>): Form<Data>
     forgetError(string: keyof Data|NamedInputEvent): Form<Data>
     setValidationTimeout(duration: number): Form<Data>,

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -4,6 +4,7 @@ export interface Form<Data extends Record<string, unknown>> {
     processing: boolean,
     validating: boolean,
     touched(name: keyof Data): boolean,
+    touch(name: string|NamedInputEvent|Array<string>): Form<Data>,
     data: Data,
     setData(key: Data|keyof Data, value?: unknown): Form<Data>,
     errors: Partial<Record<keyof Data, string>>,

--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -53,6 +53,11 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
     const form = Object.assign(inertiaForm, {
         validating: precognitiveForm.validating,
         touched: precognitiveForm.touched,
+        touch(name: Array<string>|string|NamedInputEvent) {
+            precognitiveForm.touch(name)
+
+            return form
+        },
         valid: precognitiveForm.valid,
         invalid: precognitiveForm.invalid,
         clearErrors(...names: string[]) {

--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -97,7 +97,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
 
             return form
         },
-        validate(name: string|NamedInputEvent) {
+        validate(name?: string|NamedInputEvent) {
             precognitiveForm.setData(inertiaForm.data())
 
             precognitiveForm.validate(name)

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -107,10 +107,14 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
             return form
         },
         validate(name) {
-            // @ts-expect-error
-            name = resolveName(name)
+            if (typeof name === 'undefined') {
+                validator.validate()
+            } else {
+                // @ts-expect-error
+                name = resolveName(name)
 
-            validator.validate(name, get(form.data(), name))
+                validator.validate(name, get(form.data(), name))
+            }
 
             return form
         },

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -101,6 +101,11 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
             // @ts-expect-error
             return touched.value.includes(name)
         },
+        touch(name) {
+            validator.touch(name)
+
+            return form
+        },
         validate(name) {
             // @ts-expect-error
             name = resolveName(name)

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -4,6 +4,7 @@ export interface Form<Data extends Record<string, unknown>> {
     processing: boolean,
     validating: boolean,
     touched(name: keyof Data): boolean,
+    touch(name: string|NamedInputEvent|Array<string>): Data&Form<Data>,
     data(): Data,
     setData(data: Record<string, unknown>): Data&Form<Data>,
     errors: Partial<Record<keyof Data, string>>,

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -11,7 +11,7 @@ export interface Form<Data extends Record<string, unknown>> {
     hasErrors: boolean,
     valid(name: keyof Data): boolean,
     invalid(name: keyof Data): boolean,
-    validate(name: keyof Data|NamedInputEvent): Data&Form<Data>,
+    validate(name?: keyof Data|NamedInputEvent): Data&Form<Data>,
     setErrors(errors: Partial<Record<keyof Data, string|string[]>>): Data&Form<Data>
     forgetError(string: keyof Data|NamedInputEvent): Data&Form<Data>
     setValidationTimeout(duration: number): Data&Form<Data>,


### PR DESCRIPTION
This PR allows developers to manually "touch" inputs and also invoke the "validate" method without specifying a specific input to validate.

This can be useful for multi-step forms where the form is not being submitted at the end of the page, but all field should be validated.

Because Precognition only validates "touched" inputs, which are inputs that have had the `validate` function called on them, it is not currently possible to support this kind of validation behaviour.

With this PR, it is now possible to do the following at the end of a step of a multi-step form...

```js
form.touch([
  'name',
  'email',
  'username',
  'phone',
  'address',
]).validate()
```

This will send a validation request for all the already "touched" fields and include the specified touch fields as well.

This can also be useful when a browser performs "autofill". When using React, the "change" event is highjacked, so you need a way to make several fields as "touched".

Lastly, this functionality allows for specifying that both two, or more, related fields should be considered "touch" when a single input it changed. This can be useful when there are interdependent fields...

```html
<input
    v-model="form.bank"
    @change="form.touch('account').validate('bank')"
/>
```


fixes https://github.com/laravel/precognition/issues/17