### PR TITLE
Proper return types for form helper in Inertia packages

### DIFF
--- a/packages/react-inertia/src/index.ts
+++ b/packages/react-inertia/src/index.ts
@@ -1,11 +1,11 @@
 import { Config, NamedInputEvent, RequestMethod, SimpleValidationErrors, toSimpleValidationErrors, ValidationConfig, ValidationErrors, resolveUrl, resolveMethod } from 'laravel-precognition'
-import { useForm as usePrecognitiveForm, client } from 'laravel-precognition-react'
-import { useForm as useInertiaForm } from '@inertiajs/react'
+import { useForm as usePrecognitiveForm, client, Form } from 'laravel-precognition-react'
+import { useForm as useInertiaForm, InertiaForm } from '@inertiajs/react'
 import { useRef } from 'react'
 
 export { client }
 
-export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): any => {
+export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): InertiaForm<Data> & Form<Data> => {
     const booted = useRef<boolean>(false)
 
     /**

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -6,7 +6,7 @@ import { useRef, useState } from 'react'
 import { Form } from './types'
 
 export { client }
-export * from './types';
+export * from './types'
 
 export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), input: Data, config: ValidationConfig = {}): Form<Data> => {
     /**

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -6,6 +6,7 @@ import { useRef, useState } from 'react'
 import { Form } from './types'
 
 export { client }
+export * from './types';
 
 export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), input: Data, config: ValidationConfig = {}): Form<Data> => {
     /**

--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -1,10 +1,10 @@
 import { Config, NamedInputEvent, RequestMethod, SimpleValidationErrors, toSimpleValidationErrors, ValidationConfig, ValidationErrors, resolveUrl, resolveMethod } from 'laravel-precognition'
-import { useForm as usePrecognitiveForm, client } from 'laravel-precognition-vue'
-import { useForm as useInertiaForm } from '@inertiajs/vue3'
+import { useForm as usePrecognitiveForm, client, Form } from 'laravel-precognition-vue'
+import { useForm as useInertiaForm, InertiaForm } from '@inertiajs/vue3'
 
 export { client }
 
-export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): any => {
+export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): InertiaForm<Data> & Form<Data> => {
     /**
      * The Inertia form.
      */

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -7,7 +7,7 @@ import { resolveName } from 'laravel-precognition'
 import set from 'lodash.set'
 
 export { client }
-export * from './types';
+export * from './types'
 
 export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): Data&Form<Data> => {
     /**

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -7,6 +7,7 @@ import { resolveName } from 'laravel-precognition'
 import set from 'lodash.set'
 
 export { client }
+export * from './types';
 
 export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): Data&Form<Data> => {
     /**


### PR DESCRIPTION
This PR adds return types for the `useForm` helper for the Inertia versions of precognition for Vue and React . Currently they return an `any` type, which is not the most helpful in the IDE environment as it stands.

Instead, I updated the return type to be an intersection between the Precognition's `Form` interface and Inertia's `InertiaForm` interface to get all of the methods that are available.

If this is something that was done intentionally to allow better flexibility, that is fine. I would just like for those interfaces from the Vue and React packages to be exported so they are available in the Inertia packages without having to have a dependency of those separate parent packages just to get the types.

I am not sure how to get those tests to pass given they are reliant on those changes being available in the published packages, so could use some help on getting those to pass.