### PR TITLE
[0.5.x] [BREAKING] Require `Precognition-Success` header

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -15,7 +15,7 @@ let requestFingerprintResolver: RequestFingerprintResolver = (config, axios) => 
 /**
  * The precognition success resolver.
  */
-let successResolver: SuccessResolver = (response: AxiosResponse) => response.status === 204
+let successResolver: SuccessResolver = (response: AxiosResponse) => response.status === 204 && response.headers['precognition-success'] === 'true'
 
 /**
  * The abort controller cache.


### PR DESCRIPTION
🚨 Breaking change. Requires a major version bump, i.e., `0.5.x`.

[We introduced a new header](https://github.com/laravel/framework/pull/47081) to determine if Precognition was truly successful.

To ease migration and not impact existing applications using Precognition that had not yet updated to [v10.11.0 (2023-05-16)](https://github.com/laravel/framework/blob/10.x/CHANGELOG.md#v10110-2023-05-16), I intentionally delayed adding it to our JS package.

With the introduction of the [testing helpers](https://github.com/laravel/framework/pull/48151), I felt this was a good time to make this breaking change and bring everything inline.

This is now a required header for responses, meaning that when this new version is tagged - consuming Laravel applications will need to update to `^10.11.0`.

For applications that have not yet updated to `^10.11.0`, you may put the following in your `bootstrap.js` or `app.js` to maintain the previous functionality until you can update your Laravel framework version.

### VueJS + Inertia

```js
import {client} from 'laravel-precognition-vue-inertia'

client.determineSuccessUsing(response => response.status === 204)
```

### VueJS

```js
import {client} from 'laravel-precognition-vue'

client.determineSuccessUsing(response => response.status === 204)
```

### React + Inertia

```js
import {client} from 'laravel-precognition-react-inertia'

client.determineSuccessUsing(response => response.status === 204)
```

### React

```js
import {client} from 'laravel-precognition-react'

client.determineSuccessUsing(response => response.status === 204)
```