### PR TITLE
[0.5.x] Update `processing` flag for traditional for submissions

### DIFF
--- a/packages/alpine/src/index.ts
+++ b/packages/alpine/src/index.ts
@@ -9,8 +9,6 @@ export { client }
 
 export default function (Alpine: TAlpine) {
     Alpine.magic('form', (el) => <Data extends Record<string, unknown>>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): Data&Form<Data> => {
-        syncWithDom(el, resolveMethod(method), resolveUrl(url))
-
         /**
          * The original data.
          */
@@ -162,6 +160,8 @@ export default function (Alpine: TAlpine) {
          */
         const form = Alpine.reactive(createForm()) as Data&Form<Data>
 
+        syncWithDom(el, resolveMethod(method), resolveUrl(url), form)
+
         return form
     })
 }
@@ -169,7 +169,7 @@ export default function (Alpine: TAlpine) {
 /**
  * Sync the DOM form with the Precognitive form.
  */
-const syncWithDom = (el: Node, method: RequestMethod, url: string): void => {
+const syncWithDom = <Data extends Record<string, unknown>>(el: Node, method: RequestMethod, url: string, form: Form<Data>): void => {
     if (! (el instanceof Element && el.nodeName === 'FORM')) {
         return
     }
@@ -177,6 +177,7 @@ const syncWithDom = (el: Node, method: RequestMethod, url: string): void => {
     syncSyntheticMethodInput(el, method)
     syncMethodAttribute(el, method)
     syncActionAttribute(el, url)
+    addProcessingListener(el, form)
 }
 
 /**
@@ -221,3 +222,8 @@ const syncSyntheticMethodInput = (el: Element, method: RequestMethod) => {
     input.setAttribute('name', '_method')
     input.setAttribute('value', method.toUpperCase())
 }
+
+/**
+ * Add processing listener.
+ */
+const addProcessingListener = <Data extends Record<string, unknown>>(el: Element, form: Form<Data>) => el.addEventListener('submit', () => (form.processing = true))


### PR DESCRIPTION
When using Alpine, you are able to use Precognition's client to do form submissions. When doing submissions with Precognition's client the `processing` flag is updated as expected, however when doing traditional browser submissions it isn't. This was a limitation I accepted, however I realised we can just bind an event listener to the DOM form's `submit` event and we can get feature parity for both implementations.

Now both of these examples will have the button disabled when the form is submitted.

## Browser submission

```html
<form
    x-data="{
        form: $form('post', '/register', {
            name: '',
        }),
    }"
 >
    @csrf
    <label for="name">Name</label>
    <input
        id="name"
        name="name"
        x-model="form.name"
        @change="form.validate('name')"
    />
    <template x-if="form.invalid('name')">
        <div x-text="form.errors.name"></div>
    </template>

    <label for="email">Email</label>
    <input
        id="email"
        name="email"
        x-model="form.email"
        @change="form.validate('email')"
    />
    <template x-if="form.invalid('email')">
        <div x-text="form.errors.email"></div>
    </template>

    <button :disabled="form.processing">
        Create User
    </button>
</form>
```

## Client submission


```diff
<form
    x-data="{
        form: $form('post', '/register', {
            name: '',
        }),
+         submit() {
+             this.form.submit()
+                 .then(response => {
+                     form.reset();
+
+                     alert('User created.')
+                 })
+                 .catch(error => {
+                     alert('An error occurred.');
+                 });
+         },
    }"
+    @submit.prevent="submit"
 >
    @csrf
    <label for="name">Name</label>
    <input
        id="name"
        name="name"
        x-model="form.name"
        @change="form.validate('name')"
    />
    <template x-if="form.invalid('name')">
        <div x-text="form.errors.name"></div>
    </template>

    <label for="email">Email</label>
    <input
        id="email"
        name="email"
        x-model="form.email"
        @change="form.validate('email')"
    />
    <template x-if="form.invalid('email')">
        <div x-text="form.errors.email"></div>
    </template>

    <button :disabled="form.processing">
        Create User
    </button>
</form>
```