### PR TITLE
[0.5.x] Fixes Vue w/ Inertia validating reactivity

### DIFF
--- a/packages/vue-inertia/package.json
+++ b/packages/vue-inertia/package.json
@@ -30,7 +30,8 @@
         "node": ">=14"
     },
     "peerDependencies": {
-        "@inertiajs/vue3": "^1.0.0"
+        "@inertiajs/vue3": "^1.0.0",
+        "vue": "^3.0.0"
     },
     "dependencies": {
         "laravel-precognition": "0.5.1",

--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -1,6 +1,7 @@
 import { Config, NamedInputEvent, RequestMethod, SimpleValidationErrors, toSimpleValidationErrors, ValidationConfig, ValidationErrors, resolveUrl, resolveMethod } from 'laravel-precognition'
 import { useForm as usePrecognitiveForm, client } from 'laravel-precognition-vue'
 import { useForm as useInertiaForm } from '@inertiajs/vue3'
+import { watchEffect } from 'vue'
 
 export { client }
 
@@ -142,6 +143,11 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
         },
         validator: precognitiveForm.validator,
     })
+
+    // Due to the nature of `reactive` elements, reactivity is not inherited by
+    // the patched Inertia form as we have to destructure the Precog form. We
+    // can handle this by watching for changes and apply the changes manually.
+    watchEffect(() => form.validating = precognitiveForm.validating)
 
     return form
 }


### PR DESCRIPTION
Fixes https://github.com/laravel/precognition/issues/48

When we destructure the Precognitive form, e.g.,

```js
inertiaForm.validating = precognitiveForm.validating
```

the reactivity for `validating` is not inherited. This is due to the way that Vue handles destructing `reactive` properties. 

We now watch for changes and apply them manually.