### PR TITLE
Fix Interia based `useForm` return types

### DIFF
--- a/packages/react-inertia/src/index.ts
+++ b/packages/react-inertia/src/index.ts
@@ -5,7 +5,7 @@ import { useRef } from 'react'
 
 export { client }
 
-export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): any => {
+export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}) => {
     const booted = useRef<boolean>(false)
 
     /**

--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -9,7 +9,8 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
     /**
      * The Inertia form.
      */
-    const inertiaForm = useInertiaForm(inputs)
+    const inertiaForm = useInertiaForm(inputs) as Omit<ReturnType<typeof useInertiaForm<Data>>, never>
+    // typecast can be removed/reverted when inertiajs/inertia#1734 is merged and released, tricks TS to not care for now by making it a more complex type.
 
     /**
      * The Precognitive form.

--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -5,7 +5,7 @@ import { watchEffect } from 'vue'
 
 export { client }
 
-export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): any => {
+export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}) => {
     /**
      * The Inertia form.
      */


### PR DESCRIPTION
This will give us usable types for `useForm` for React and Vue 3 when using Inertia. Related to #31, but not dependant on it.

For now, builds will fail for Vue until inertiajs/inertia#1734 is merged and released, but React will work out of the box. If one wants to test it locally, you can manually fix `@inertiajs/vue3` for Typescript's particularities by editing `@inertiajs/vue3/types/useForm.d.ts` to export it's `InertiaFormProps`.