### PR TITLE
[0.8.x] Fix incorrectly reported valid inputs

### DIFF
--- a/packages/alpine/src/index.ts
+++ b/packages/alpine/src/index.ts
@@ -47,6 +47,8 @@ export default function (Alpine: TAlpine) {
                 form.hasErrors = validator.hasErrors()
 
                 form.errors = toSimpleValidationErrors(validator.errors())
+
+                state.valid = validator.valid()
             })
 
         /**

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -29,6 +29,12 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
      */
     let validating = false
 
+    /**
+     * Set the validating inputs.
+     *
+     * Returns an array of listeners that should be invoked once all state
+     * changes have taken place.
+     */
     const setValidating = (value: boolean): (() => void)[] => {
         if (value !== validating) {
             validating = value
@@ -44,6 +50,12 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
      */
     let validated: Array<string> = []
 
+    /**
+     * Set the validated inputs.
+     *
+     * Returns an array of listeners that should be invoked once all state
+     * changes have taken place.
+     */
     const setValidated = (value: Array<string>): (() => void)[] => {
         const uniqueNames = [...new Set(value)]
 
@@ -59,15 +71,19 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
     /**
      * Valid validation state.
      */
-    const valid = () => {
-        return validated.filter(name => typeof errors[name] === 'undefined')
-    }
+    const valid = () => validated.filter(name => typeof errors[name] === 'undefined')
 
     /**
      * Touched input state.
      */
     let touched: Array<string> = []
 
+    /**
+     * Set the touched inputs.
+     *
+     * Returns an array of listeners that should be invoked once all state
+     * changes have taken place.
+     */
     const setTouched = (value: Array<string>): (() => void)[] => {
         const uniqueNames = [...new Set(value)]
 
@@ -85,6 +101,12 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
      */
     let errors: ValidationErrors = {}
 
+    /**
+     * Set the input errors.
+     *
+     * Returns an array of listeners that should be invoked once all state
+     * changes have taken place.
+     */
     const setErrors = (value: ValidationErrors|SimpleValidationErrors): (() => void)[] => {
         const prepared = toValidationErrors(value)
 
@@ -97,6 +119,12 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
         return []
     }
 
+    /**
+     * Forget the given input's errors.
+     *
+     * Returns an array of listeners that should be invoked once all state
+     * changes have taken place.
+     */
     const forgetError = (name: string|NamedInputEvent): (() => void)[] => {
         const newErrors = { ...errors }
 
@@ -188,7 +216,7 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
             onPrecognitionSuccess: (response) => {
                 [
                     ...setValidated([...validated, ...validate]),
-                    ...setErrors({}),
+                    ...setErrors(omit({ ...errors }, validate)),
                 ].forEach(listener => listener())
 
                 return config.onPrecognitionSuccess

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -87,6 +87,8 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
 
                 // @ts-expect-error
                 setErrors(toSimpleValidationErrors(validator.current!.errors()))
+
+                setValid(validator.current!.valid())
             })
     }
 

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -48,6 +48,9 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
 
             // @ts-expect-error
             form.errors = toSimpleValidationErrors(validator.errors())
+
+            // @ts-expect-error
+            valid.value = validator.valid()
         })
 
     /**


### PR DESCRIPTION
fixes https://github.com/laravel/precognition/issues/58

It is possible for Precognition to get out of sync with what inputs are reported as being "valid".

This fixes the issue by:

1. Delaying listeners until all state has been updated.
2. Making sure the library specific implementations update their "valid" state when errors change.

Note: The reported "invalid" inputs are _always_ correct and not impacted by this bug.