### PR TITLE
[0.5.x] Migrate to lodash-es

### DIFF
--- a/packages/alpine/package.json
+++ b/packages/alpine/package.json
@@ -32,15 +32,11 @@
     },
     "dependencies": {
         "laravel-precognition": "0.5.3",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.get": "^4.4.2",
-        "lodash.set": "^4.3.2"
+        "lodash": "^4.17.21"
     },
     "devDependencies": {
         "@types/alpinejs": "^3.7.1",
-        "@types/lodash.clonedeep": "^4.5.7",
-        "@types/lodash.get": "^4.4.7",
-        "@types/lodash.set": "^4.3.7",
+        "@types/lodash": "^4.14.202",
         "typescript": "^5.0.0"
     }
 }

--- a/packages/alpine/package.json
+++ b/packages/alpine/package.json
@@ -32,11 +32,11 @@
     },
     "dependencies": {
         "laravel-precognition": "0.5.3",
-        "lodash": "^4.17.21"
+        "lodash-es": "^4.17.21"
     },
     "devDependencies": {
         "@types/alpinejs": "^3.7.1",
-        "@types/lodash": "^4.14.202",
+        "@types/lodash-es": "^4.17.12",
         "typescript": "^5.0.0"
     }
 }

--- a/packages/alpine/src/index.ts
+++ b/packages/alpine/src/index.ts
@@ -1,8 +1,6 @@
 import { Alpine as TAlpine } from 'alpinejs'
 import { client, Config, createValidator, RequestMethod, resolveName, toSimpleValidationErrors, ValidationConfig, resolveUrl, resolveMethod } from 'laravel-precognition'
-import cloneDeep from 'lodash/clonedeep'
-import get from 'lodash/get'
-import set from 'lodash/set'
+import {cloneDeep, get, set} from 'lodash-es'
 import { Form } from './types.js'
 
 export { client }

--- a/packages/alpine/src/index.ts
+++ b/packages/alpine/src/index.ts
@@ -1,8 +1,8 @@
 import { Alpine as TAlpine } from 'alpinejs'
 import { client, Config, createValidator, RequestMethod, resolveName, toSimpleValidationErrors, ValidationConfig, resolveUrl, resolveMethod } from 'laravel-precognition'
-import cloneDeep from 'lodash.clonedeep'
-import get from 'lodash.get'
-import set from 'lodash.set'
+import cloneDeep from 'lodash/clonedeep'
+import get from 'lodash/get'
+import set from 'lodash/set'
 import { Form } from './types.js'
 
 export { client }

--- a/packages/alpine/src/index.ts
+++ b/packages/alpine/src/index.ts
@@ -1,6 +1,6 @@
 import { Alpine as TAlpine } from 'alpinejs'
 import { client, Config, createValidator, RequestMethod, resolveName, toSimpleValidationErrors, ValidationConfig, resolveUrl, resolveMethod } from 'laravel-precognition'
-import {cloneDeep, get, set} from 'lodash-es'
+import { cloneDeep, get, set } from 'lodash-es'
 import { Form } from './types.js'
 
 export { client }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,10 +29,10 @@
     },
     "dependencies": {
         "axios": "^1.4.0",
-        "lodash": "^4.17.21"
+        "lodash-es": "^4.17.21"
     },
     "devDependencies": {
-        "@types/lodash": "^4.14.202",
+        "@types/lodash-es": "^4.17.12",
         "@types/node": "^20.1.0",
         "typescript": "^5.0.0",
         "vitest": "^0.31.3"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,20 +29,10 @@
     },
     "dependencies": {
         "axios": "^1.4.0",
-        "lodash.debounce": "^4.0.8",
-        "lodash.get": "^4.4.2",
-        "lodash.isequal": "^4.0.8",
-        "lodash.merge": "^4.6.2",
-        "lodash.omit": "^4.5.0",
-        "lodash.set": "^4.3.2"
+        "lodash": "^4.17.21"
     },
     "devDependencies": {
-        "@types/lodash.debounce": "^4.0.7",
-        "@types/lodash.get": "^4.4.7",
-        "@types/lodash.isequal": "^4.0.7",
-        "@types/lodash.merge": "^4.0.7",
-        "@types/lodash.omit": "^4.5.7",
-        "@types/lodash.set": "^4.3.7",
+        "@types/lodash": "^4.14.202",
         "@types/node": "^20.1.0",
         "typescript": "^5.0.0",
         "vitest": "^0.31.3"

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1,5 +1,5 @@
 import { isAxiosError, isCancel, AxiosInstance, AxiosResponse, default as Axios } from 'axios'
-import merge from 'lodash/merge'
+import {merge} from 'lodash-es'
 import { Config, Client, RequestFingerprintResolver, StatusHandler, SuccessResolver, RequestMethod } from './types.js'
 
 /**

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1,5 +1,5 @@
 import { isAxiosError, isCancel, AxiosInstance, AxiosResponse, default as Axios } from 'axios'
-import merge from 'lodash.merge'
+import merge from 'lodash/merge'
 import { Config, Client, RequestFingerprintResolver, StatusHandler, SuccessResolver, RequestMethod } from './types.js'
 
 /**

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1,5 +1,5 @@
 import { isAxiosError, isCancel, AxiosInstance, AxiosResponse, default as Axios } from 'axios'
-import {merge} from 'lodash-es'
+import { merge } from 'lodash-es'
 import { Config, Client, RequestFingerprintResolver, StatusHandler, SuccessResolver, RequestMethod } from './types.js'
 
 /**

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -1,12 +1,7 @@
-import debounce from 'lodash/debounce'
-import isequal from 'lodash/isequal'
-import get from 'lodash/get'
-import set from 'lodash/set'
+import { debounce, isEqual, get, set, omit, merge } from 'lodash-es'
 import { ValidationCallback, Config, NamedInputEvent, SimpleValidationErrors, ValidationErrors, Validator as TValidator, ValidatorListeners, ValidationConfig } from './types.js'
 import { client, isFile } from './client.js'
 import { isAxiosError } from 'axios'
-import omit from 'lodash/omit'
-import merge from 'lodash/merge'
 
 export const createValidator = (callback: ValidationCallback, initialData: Record<string, unknown> = {}): TValidator => {
     /**
@@ -110,7 +105,7 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
     const setErrors = (value: ValidationErrors|SimpleValidationErrors): (() => void)[] => {
         const prepared = toValidationErrors(value)
 
-        if (! isequal(errors, prepared)) {
+        if (! isEqual(errors, prepared)) {
             errors = prepared
 
             return listeners.errorsChanged
@@ -225,7 +220,7 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
             },
             onBefore: () => {
                 const beforeValidationResult = (config.onBeforeValidation ?? ((previous, next) => {
-                    return ! isequal(previous, next)
+                    return ! isEqual(previous, next)
                 }))({ data, touched }, { data: oldData, touched: oldTouched })
 
                 if (beforeValidationResult === false) {

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -1,12 +1,12 @@
-import debounce from 'lodash.debounce'
-import isequal from 'lodash.isequal'
-import get from 'lodash.get'
-import set from 'lodash.set'
+import debounce from 'lodash/debounce'
+import isequal from 'lodash/isequal'
+import get from 'lodash/get'
+import set from 'lodash/set'
 import { ValidationCallback, Config, NamedInputEvent, SimpleValidationErrors, ValidationErrors, Validator as TValidator, ValidatorListeners, ValidationConfig } from './types.js'
 import { client, isFile } from './client.js'
 import { isAxiosError } from 'axios'
-import omit from 'lodash.omit'
-import merge from 'lodash.merge'
+import omit from 'lodash/omit'
+import merge from 'lodash/merge'
 
 export const createValidator = (callback: ValidationCallback, initialData: Record<string, unknown> = {}): TValidator => {
     /**

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,14 +32,10 @@
     },
     "dependencies": {
         "laravel-precognition": "0.5.3",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.get": "^4.4.2",
-        "lodash.set": "^4.3.2"
+        "lodash": "^4.17.21"
     },
     "devDependencies": {
-        "@types/lodash.clonedeep": "^4.5.7",
-        "@types/lodash.get": "^4.4.7",
-        "@types/lodash.set": "^4.3.7",
+        "@types/lodash": "^4.14.202",
         "@types/react": "^18.2.6",
         "typescript": "^5.0.0"
     }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,10 +32,10 @@
     },
     "dependencies": {
         "laravel-precognition": "0.5.3",
-        "lodash": "^4.17.21"
+        "lodash-es": "^4.17.21"
     },
     "devDependencies": {
-        "@types/lodash": "^4.14.202",
+        "@types/lodash-es": "^4.17.12",
         "@types/react": "^18.2.6",
         "typescript": "^5.0.0"
     }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,7 +1,7 @@
 import { resolveName, client, createValidator, Config, RequestMethod, Validator, toSimpleValidationErrors, ValidationConfig, resolveUrl, resolveMethod } from 'laravel-precognition'
-import cloneDeep from 'lodash.clonedeep'
-import get from 'lodash.get'
-import set from 'lodash.set'
+import cloneDeep from 'lodash/cloneDeep'
+import get from 'lodash/get'
+import set from 'lodash/set'
 import { useRef, useState } from 'react'
 import { Form } from './types.js'
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,7 +1,5 @@
 import { resolveName, client, createValidator, Config, RequestMethod, Validator, toSimpleValidationErrors, ValidationConfig, resolveUrl, resolveMethod } from 'laravel-precognition'
-import cloneDeep from 'lodash/cloneDeep'
-import get from 'lodash/get'
-import set from 'lodash/set'
+import { cloneDeep, get, set } from 'lodash-es'
 import { useRef, useState } from 'react'
 import { Form } from './types.js'
 

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -32,14 +32,10 @@
     },
     "dependencies": {
         "laravel-precognition": "0.5.3",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.get": "^4.4.2",
-        "lodash.set": "^4.3.2"
+        "lodash": "^4.17.21"
     },
     "devDependencies": {
-        "@types/lodash.clonedeep": "^4.5.7",
-        "@types/lodash.get": "^4.4.7",
-        "@types/lodash.set": "^4.3.7",
+        "@types/lodash": "^4.14.202",
         "typescript": "^5.0.0"
     }
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -32,10 +32,10 @@
     },
     "dependencies": {
         "laravel-precognition": "0.5.3",
-        "lodash": "^4.17.21"
+        "lodash-es": "^4.17.21"
     },
     "devDependencies": {
-        "@types/lodash": "^4.14.202",
+        "@types/lodash-es": "^4.17.12",
         "typescript": "^5.0.0"
     }
 }

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,9 +1,7 @@
 import { Config, RequestMethod, client, createValidator, toSimpleValidationErrors, ValidationConfig, resolveUrl, resolveMethod , resolveName } from 'laravel-precognition'
 import { Form } from './types.js'
 import { reactive, ref, toRaw } from 'vue'
-import cloneDeep from 'lodash/clonedeep'
-import get from 'lodash/get'
-import set from 'lodash/set'
+import {cloneDeep, get, set} from 'lodash-es'
 
 export { client }
 

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,7 +1,7 @@
 import { Config, RequestMethod, client, createValidator, toSimpleValidationErrors, ValidationConfig, resolveUrl, resolveMethod , resolveName } from 'laravel-precognition'
 import { Form } from './types.js'
 import { reactive, ref, toRaw } from 'vue'
-import {cloneDeep, get, set} from 'lodash-es'
+import { cloneDeep, get, set } from 'lodash-es'
 
 export { client }
 

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,9 +1,9 @@
 import { Config, RequestMethod, client, createValidator, toSimpleValidationErrors, ValidationConfig, resolveUrl, resolveMethod , resolveName } from 'laravel-precognition'
 import { Form } from './types.js'
 import { reactive, ref, toRaw } from 'vue'
-import cloneDeep from 'lodash.clonedeep'
-import get from 'lodash.get'
-import set from 'lodash.set'
+import cloneDeep from 'lodash/clonedeep'
+import get from 'lodash/get'
+import set from 'lodash/set'
 
 export { client }
 


### PR DESCRIPTION
This pull request represents a significant enhancement to our project's dependency management and security posture. We are transitioning from using individual lodash packages to the unified lodash package. This change is motivated by two primary factors: the discontinuation of maintenance for individual lodash modules and a critical security vulnerability in lodash.set.

Key changes:

- Unified Lodash Package: All individual lodash packages (lodash.*) are replaced with the single, comprehensive lodash package. This consolidation simplifies dependency management and ensures we are using the most up-to-date and supported version of lodash.

- Security lodash.set: The individual lodash.set package currently utilized in our project has a known prototype pollution vulnerability (CWE-1321). By switching to the unified lodash package, we address this security issue, as the latest version of lodash has resolved this vulnerability.

Scope:

- Only focus on the `react` package for now