### PR TITLE
Vue + Inertia useForm now uses an object compatible signature

### DIFF
--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -62,6 +62,7 @@ export const useForm = <Data extends object>(method: RequestMethod|(() => Reques
         valid: precognitiveForm.valid,
         invalid: precognitiveForm.invalid,
         clearErrors(...names: string[]) {
+            // @ts-expect-error
             inertiaClearErrors(...names)
 
             if (names.length === 0) {
@@ -73,12 +74,12 @@ export const useForm = <Data extends object>(method: RequestMethod|(() => Reques
             return form
         },
         reset(...names: string[]) {
+            // @ts-expect-error
             inertiaReset(...names)
 
             precognitiveForm.reset(...names)
         },
         setErrors(errors: SimpleValidationErrors|ValidationErrors) {
-            // @ts-expect-error
             precognitiveForm.setErrors(errors)
 
             return form
@@ -99,7 +100,7 @@ export const useForm = <Data extends object>(method: RequestMethod|(() => Reques
             return form
         },
         validate(name?: string|NamedInputEvent) {
-            precognitiveForm.setData(inertiaForm.data())
+            precognitiveForm.setData(inertiaForm.data() as Record<string, unknown>)
 
             precognitiveForm.validate(name)
 
@@ -130,7 +131,7 @@ export const useForm = <Data extends object>(method: RequestMethod|(() => Reques
                 ? resolveMethod(method)
                 : submitMethod as RequestMethod
 
-            inertiaSubmit(submitMethod, submitUrl, {
+            inertiaSubmit(submitMethod, submitUrl as string, {
                 ...submitOptions,
                 onError: (errors: SimpleValidationErrors): any => {
                     precognitiveForm.validator().setErrors(errors)

--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -5,7 +5,7 @@ import { watchEffect } from 'vue'
 
 export { client }
 
-export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): any => {
+export const useForm = <Data extends object>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): any => {
     /**
      * The Inertia form.
      */
@@ -14,7 +14,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
     /**
      * The Precognitive form.
      */
-    const precognitiveForm = usePrecognitiveForm(method, url, inputs, config)
+    const precognitiveForm = usePrecognitiveForm(method, url, inputs as Record<string, unknown>, config)
 
     /**
      * Setup event listeners.


### PR DESCRIPTION
This is the solution to https://github.com/laravel/precognition/issues/63.

The signature for "useForm" (Vue + InertiaJS package) was changed to object instead of Record<string, unknown> so it's going to be compatible with the native InertiaJS "useForm" that accepts also an object (type FormDataType = object).

"usePrecognitiveForm" type was hydrated as Record<string, unknown> so it should not break the compatibility.

Record<string, unknown> it's basically an object, so everything should work as expected.

I did a [test with with Typescript 5.3.3](https://www.typescriptlang.org/play?#code/MYewdgzgLgBBCuAjAYvMwYF4YAoBuAhgDYBcMASgKagBOAJgDzQ0CWYA5gDQxoDWYIAO5gAfAEosImAG8AUDAUwalKPBpgYhIgG5ZAX1mhIsALYE2qdFhgMAIgSgEYlAB5RKYOhBghEAK2ooERw2AAd4KAgye0cJSRl5RWVVdTgkS2AQsHDImAJvKlpGZjYuHjB+IVExXQNZNncaADMCYEoYGIJCkHoExRgwAhNKMhKOTkSFLXgRgfgTREoaWtlDcGgYOgcnaO3u3uw5fsHhsgAiABVKaDOJ-unZgE5Hib1dWTMLNEyt2PegA).



