### PR TITLE
Provided signature and partial type compatibility with InertiaJS

### DIFF
--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -1,11 +1,47 @@
-import { Config, NamedInputEvent, RequestMethod, SimpleValidationErrors, toSimpleValidationErrors, ValidationConfig, ValidationErrors, resolveUrl, resolveMethod } from 'laravel-precognition'
+import { Config, NamedInputEvent, RequestMethod, SimpleValidationErrors, toSimpleValidationErrors, ValidationConfig, ValidationErrors, resolveUrl, resolveMethod, Validator } from 'laravel-precognition'
 import { useForm as usePrecognitiveForm, client } from 'laravel-precognition-vue'
 import { useForm as useInertiaForm } from '@inertiajs/vue3'
+import { FormDataConvertible, Progress, VisitOptions } from '@inertiajs/core'
+
 import { watchEffect } from 'vue'
 
 export { client }
 
-export const useForm = <Data extends object>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): any => {
+type FormDataType = object;
+
+interface PrecognitionFormProps<TForm extends FormDataType> {
+    validating: boolean,                                                // Patched
+    isDirty: boolean;
+    errors: Partial<Record<keyof TForm, string>>;
+    hasErrors: boolean;
+    processing: boolean;
+    progress: Progress | null;                                          // Patched
+    wasSuccessful: boolean;
+    recentlySuccessful: boolean;
+    data(): TForm;
+    transform(callback: (data: TForm) => object): this;
+    defaults(): this;
+    defaults(field: keyof TForm, value: FormDataConvertible): this;
+    defaults(fields: Partial<TForm>): this;
+    reset(...fields: (keyof TForm)[]): this;
+    clearErrors(...fields: (keyof TForm)[]): this;
+    touched(name: string): boolean,                                     // Patched
+    touch(name: string | string[] | NamedInputEvent): this;             // Patched
+    submit(submitMethod: RequestMethod|Config, submitUrl?: string, submitOptions?: Partial<VisitOptions>): void; // Patched
+    cancel(): void;
+    setErrors(errors: SimpleValidationErrors|ValidationErrors) : this;  // Patched
+    forgetError(name: string|NamedInputEvent): this;                    // Patched
+    setError(field: keyof TForm, value: string): this;                  // Patched
+    validate(name?: string|NamedInputEvent): this;                      // Patched
+    setValidationTimeout(duration: number): this;
+    validateFiles(): this;
+    validator(): Validator;                                             // Patched
+    valid(name: string | NamedInputEvent | string[]): boolean,          // Patched
+    invalid(name: string): boolean,                                     // Patched
+}
+
+
+export const useForm = <Data extends FormDataType>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): PrecognitionFormProps<Data> & Data => {
     /**
      * The Inertia form.
      */
@@ -61,23 +97,22 @@ export const useForm = <Data extends object>(method: RequestMethod|(() => Reques
         },
         valid: precognitiveForm.valid,
         invalid: precognitiveForm.invalid,
-        clearErrors(...names: string[]) {
-            // @ts-expect-error
-            inertiaClearErrors(...names)
+        clearErrors(...fields: (keyof Data)[]) {
+            inertiaClearErrors(...fields)
 
-            if (names.length === 0) {
+            if (fields.length === 0) {
                 precognitiveForm.setErrors({})
             } else {
-                names.forEach(precognitiveForm.forgetError)
+                // @ts-expect-error
+                fields.forEach(precognitiveForm.forgetError)
             }
 
             return form
         },
-        reset(...names: string[]) {
-            // @ts-expect-error
-            inertiaReset(...names)
+        reset(...fields: (keyof Data)[]) {
+            inertiaReset(...fields)
 
-            precognitiveForm.reset(...names)
+            precognitiveForm.reset(...fields as string[])
         },
         setErrors(errors: SimpleValidationErrors|ValidationErrors) {
             precognitiveForm.setErrors(errors)

--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -62,6 +62,7 @@ export const useForm = <Data extends object>(method: RequestMethod|(() => Reques
         valid: precognitiveForm.valid,
         invalid: precognitiveForm.invalid,
         clearErrors(...names: string[]) {
+            // @ts-expect-error
             inertiaClearErrors(...names)
 
             if (names.length === 0) {
@@ -73,12 +74,12 @@ export const useForm = <Data extends object>(method: RequestMethod|(() => Reques
             return form
         },
         reset(...names: string[]) {
+            // @ts-expect-error
             inertiaReset(...names)
 
             precognitiveForm.reset(...names)
         },
         setErrors(errors: SimpleValidationErrors|ValidationErrors) {
-            // @ts-expect-error
             precognitiveForm.setErrors(errors)
 
             return form
@@ -99,7 +100,7 @@ export const useForm = <Data extends object>(method: RequestMethod|(() => Reques
             return form
         },
         validate(name?: string|NamedInputEvent) {
-            precognitiveForm.setData(inertiaForm.data())
+            precognitiveForm.setData(inertiaForm.data() as Record<string, unknown>)
 
             precognitiveForm.validate(name)
 
@@ -130,7 +131,7 @@ export const useForm = <Data extends object>(method: RequestMethod|(() => Reques
                 ? resolveMethod(method)
                 : submitMethod as RequestMethod
 
-            inertiaSubmit(submitMethod, submitUrl, {
+            inertiaSubmit(submitMethod, submitUrl as string, {
                 ...submitOptions,
                 onError: (errors: SimpleValidationErrors): any => {
                     precognitiveForm.validator().setErrors(errors)

--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -5,7 +5,7 @@ import { watchEffect } from 'vue'
 
 export { client }
 
-export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): any => {
+export const useForm = <Data extends object>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): any => {
     /**
      * The Inertia form.
      */
@@ -14,7 +14,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
     /**
      * The Precognitive form.
      */
-    const precognitiveForm = usePrecognitiveForm(method, url, inputs, config)
+    const precognitiveForm = usePrecognitiveForm(method, url, inputs as Record<string, unknown>, config)
 
     /**
      * Setup event listeners.


### PR DESCRIPTION
I did some rework on the vue-inertia package in order to make it compatible with the original InertiaJS "useForm":

**Changes**
- Precognition "useForm" will accept object type like InertiaJS:

```
import {useForm} from 'laravel-precognition-vue-inertia'
const form = useForm<MyInterface>('post', 'https://example.net', mydata);
// or  useForm('post', 'https://example.net', mydata as MyInterface);
```
- Precognition "useForm" will return the original InertiaJS properties and methods patched with the Precognition properties and methods (I added the types). 

- Original interface properties are also exposed.

**Advantages of this change**
- Original interface properties and Precognition properties and methods are exposed to the linter.
- Better Typescript support.
- Increased signature compatibility with InertiaJS.
- It doesn't require any change in the Precognition core libraries or precognition-vue package.

**Disadvantages of this change**
- It may require to update the return type in case that original InertiaJS "useForm" method change any of their return properties or method.