### PR TITLE
support async validate

### DIFF
--- a/packages/alpine/src/index.ts
+++ b/packages/alpine/src/index.ts
@@ -95,13 +95,13 @@ export default function (Alpine: TAlpine) {
 
                 return form
             },
-            validate(name) {
+            async validate(name) {
                 if (typeof name === 'undefined') {
-                    validator.validate()
+                    await validator.validate()
                 } else {
                     name = resolveName(name)
 
-                    validator.validate(name, get(form.data(), name))
+                    await validator.validate(name, get(form.data(), name))
                 }
 
                 return form

--- a/packages/alpine/src/types.ts
+++ b/packages/alpine/src/types.ts
@@ -10,7 +10,7 @@ export interface Form<Data extends Record<string, unknown>> {
     hasErrors: boolean,
     valid(name: string): boolean,
     invalid(name: string): boolean,
-    validate(name?: string|NamedInputEvent): Data&Form<Data>,
+    validate(name?: string|NamedInputEvent): Promise<Data&Form<Data>>,
     setErrors(errors: SimpleValidationErrors|ValidationErrors): Data&Form<Data>
     forgetError(name: string|NamedInputEvent): Data&Form<Data>
     setValidationTimeout(duration: number): Data&Form<Data>,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -50,7 +50,7 @@ export interface Client {
 
 export interface Validator {
     touched(): Array<string>,
-    validate(input?: string|NamedInputEvent, value?: unknown): Validator,
+    validate(input?: string|NamedInputEvent, value?: unknown): Promise<Validator>,
     touch(input: string|NamedInputEvent|Array<string>): Validator,
     validating(): boolean,
     valid(): Array<string>,

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -178,11 +178,10 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
                 put: (url, data = {}, config = {}) => client.put(url, parseData(data), resolveConfig(config, data)),
                 delete: (url, data = {}, config = {}) => client.delete(url, parseData(data), resolveConfig(config, data)),
             })
-                .then(resolve)
-                .catch(error => isAxiosError(error) ? resolve(null) : reject(error))
-        }
-        )
-    } , debounceTimeoutDuration, { leading: true, trailing: true })
+            .then(resolve)
+            .catch(error => isAxiosError(error) ? resolve(null) : reject(error))
+        })
+    }, debounceTimeoutDuration, { leading: true, trailing: true })
 
     /**
      * Validator state.

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -143,14 +143,14 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
 
             return form
         },
-        validate(name) {
+        async validate(name) {
             if (typeof name === 'undefined') {
-                validator.current!.validate()
+                await validator.current!.validate()
             } else {
                 // @ts-expect-error
                 name = resolveName(name)
 
-                validator.current!.validate(name, get(payload.current, name))
+                await validator.current!.validate(name, get(payload.current, name))
             }
 
             return form

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -11,7 +11,7 @@ export interface Form<Data extends Record<string, unknown>> {
     hasErrors: boolean,
     valid(name: keyof Data): boolean,
     invalid(name: keyof Data): boolean,
-    validate(name?: keyof Data|NamedInputEvent): Form<Data>,
+    validate(name?: keyof Data|NamedInputEvent): Promise<Form<Data>>,
     setErrors(errors: Partial<Record<keyof Data, string|string[]>>): Form<Data>
     forgetError(string: keyof Data|NamedInputEvent): Form<Data>
     setValidationTimeout(duration: number): Form<Data>,

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -106,14 +106,14 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
 
             return form
         },
-        validate(name) {
+        async validate(name) {
             if (typeof name === 'undefined') {
-                validator.validate()
+                await validator.validate()
             } else {
                 // @ts-expect-error
                 name = resolveName(name)
 
-                validator.validate(name, get(form.data(), name))
+                await validator.validate(name, get(form.data(), name))
             }
 
             return form

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -11,7 +11,7 @@ export interface Form<Data extends Record<string, unknown>> {
     hasErrors: boolean,
     valid(name: keyof Data): boolean,
     invalid(name: keyof Data): boolean,
-    validate(name?: keyof Data|NamedInputEvent): Data&Form<Data>,
+    validate(name?: keyof Data|NamedInputEvent): Promise<Data&Form<Data>>,
     setErrors(errors: Partial<Record<keyof Data, string|string[]>>): Data&Form<Data>
     forgetError(string: keyof Data|NamedInputEvent): Data&Form<Data>
     setValidationTimeout(duration: number): Data&Form<Data>,


### PR DESCRIPTION
Make `form.validate` function async just like `form.submit` to be able to await the validation process.

Fixes #59 