### PR TITLE
[1.x] Async validate

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,13 +11,14 @@
     "scripts": {
         "build": "npm run build --workspaces",
         "link": "npm link --workspaces",
-        "lint": "eslint --ext .ts --ignore-pattern dist ./packages",
-        "lint:fix": "eslint --fix --ext .ts --ignore-pattern dist ./packages",
+        "typeCheck": "npm run typeCheck --workspaces",
+        "lint": "eslint --ignore-pattern /packages/**/dist/** ./packages/**",
+        "lint:fix": "eslint --fix --ignore-pattern /packages/**/dist/** ./packages/**",
         "test": "npm run test --workspaces --if-present"
     },
     "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.21.0",
-        "@typescript-eslint/parser": "^5.21.0",
-        "eslint": "^8.14.0"
+        "@typescript-eslint/eslint-plugin": "^7.10.0",
+        "@typescript-eslint/parser": "^7.10.0",
+        "eslint": "^8.56.0"
     }
 }

--- a/packages/alpine/package.json
+++ b/packages/alpine/package.json
@@ -21,6 +21,7 @@
     ],
     "scripts": {
         "build": "rm -rf dist && tsc",
+        "typeCheck": "tsc --noEmit",
         "prepublishOnly": "npm run build",
         "version": "npm pkg set dependencies.laravel-precognition=$npm_package_version"
     },

--- a/packages/alpine/src/index.ts
+++ b/packages/alpine/src/index.ts
@@ -95,13 +95,18 @@ export default function (Alpine: TAlpine) {
 
                 return form
             },
-            validate(name) {
+            validate(name, config) {
+                if (typeof name === 'object' && !('target' in name)) {
+                    config = name
+                    name = undefined
+                }
+
                 if (typeof name === 'undefined') {
-                    validator.validate()
+                    validator.validate(config)
                 } else {
                     name = resolveName(name)
 
-                    validator.validate(name, get(form.data(), name))
+                    validator.validate(name, get(form.data(), name), config)
                 }
 
                 return form

--- a/packages/alpine/src/types.ts
+++ b/packages/alpine/src/types.ts
@@ -1,4 +1,4 @@
-import { Config, NamedInputEvent, SimpleValidationErrors, ValidationErrors } from 'laravel-precognition'
+import { Config, NamedInputEvent, SimpleValidationErrors, ValidationConfig, ValidationErrors } from 'laravel-precognition'
 
 export interface Form<Data extends Record<string, unknown>> {
     processing: boolean,
@@ -10,7 +10,7 @@ export interface Form<Data extends Record<string, unknown>> {
     hasErrors: boolean,
     valid(name: string): boolean,
     invalid(name: string): boolean,
-    validate(name?: string|NamedInputEvent): Data&Form<Data>,
+    validate(name?: string|NamedInputEvent|ValidationConfig, config?: ValidationConfig): Data&Form<Data>,
     setErrors(errors: SimpleValidationErrors|ValidationErrors): Data&Form<Data>
     forgetError(name: string|NamedInputEvent): Data&Form<Data>
     setValidationTimeout(duration: number): Data&Form<Data>,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,7 @@
     ],
     "scripts": {
         "build": "rm -rf dist && tsc",
+        "typeCheck": "tsc --noEmit",
         "prepublishOnly": "npm run build",
         "test": "vitest run"
     },
@@ -35,6 +36,6 @@
         "@types/lodash-es": "^4.17.12",
         "@types/node": "^20.1.0",
         "typescript": "^5.0.0",
-        "vitest": "^0.31.3"
+        "vitest": "^1.6.0"
     }
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -50,7 +50,7 @@ export interface Client {
 
 export interface Validator {
     touched(): Array<string>,
-    validate(input?: string|NamedInputEvent, value?: unknown): Validator,
+    validate(input?: string|NamedInputEvent|ValidationConfig, value?: unknown, config?: ValidationConfig): Validator,
     touch(input: string|NamedInputEvent|Array<string>): Validator,
     validating(): boolean,
     valid(): Array<string>,
@@ -87,4 +87,8 @@ interface NamedEventTarget extends EventTarget {
 
 export interface NamedInputEvent extends InputEvent {
     readonly target: NamedEventTarget;
+}
+
+declare module 'axios' {
+    export function mergeConfig(config1: AxiosRequestConfig, config2: AxiosRequestConfig): AxiosRequestConfig
 }

--- a/packages/core/tests/client.test.js
+++ b/packages/core/tests/client.test.js
@@ -218,7 +218,7 @@ it('does not consider 204 response to be success without "Precognition-Success" 
         },
         onSuccess() {
             responseSuccess = true
-        }
+        },
     })
 
     expect(precognitionSucess).toBe(false)
@@ -229,7 +229,7 @@ it('throws an error if the precognition header is not present on an error respon
     expect.assertions(2)
 
     axios.request.mockRejectedValueOnce({ response: { status: 500 } })
-    axios.isAxiosError.mockReturnValue(true)
+    axios.isAxiosError.mockReturnValueOnce(true)
 
     await client.get('https://laravel.com').catch((e) => {
         expect(e).toBeInstanceOf(Error)
@@ -249,7 +249,7 @@ it('returns a non-axios error via a rejected promise', async () => {
     })
 })
 
-it('returns a canceled request error va rejected promise', async () => {
+it('returns a cancelled request error va rejected promise', async () => {
     expect.assertions(1)
 
     const error = { expected: 'error' }
@@ -519,29 +519,29 @@ it('overrides the request data with the config data', async () => {
     })
 
     await client.get('https://laravel.com', { expected: false }, {
-        data: { expected: true }
+        data: { expected: true },
     })
-    expect(config.data).toEqual({ expected: true})
+    expect(config.data).toEqual({ expected: true })
 
     await client.post('https://laravel.com', { expected: false }, {
-        data: { expected: true }
+        data: { expected: true },
     })
-    expect(config.data).toEqual({ expected: true})
+    expect(config.data).toEqual({ expected: true })
 
     await client.patch('https://laravel.com', { expected: false }, {
-        data: { expected: true }
+        data: { expected: true },
     })
-    expect(config.data).toEqual({ expected: true})
+    expect(config.data).toEqual({ expected: true })
 
     await client.put('https://laravel.com', { expected: false }, {
-        data: { expected: true }
+        data: { expected: true },
     })
-    expect(config.data).toEqual({ expected: true})
+    expect(config.data).toEqual({ expected: true })
 
     await client.delete('https://laravel.com', { expected: false }, {
-        data: { expected: true }
+        data: { expected: true },
     })
-    expect(config.data).toEqual({ expected: true})
+    expect(config.data).toEqual({ expected: true })
 })
 
 it('merges request data with config data', async () => {
@@ -554,28 +554,28 @@ it('merges request data with config data', async () => {
     })
 
     await client.get('https://laravel.com', { request: true }, {
-        data: { config: true }
+        data: { config: true },
     })
     expect(config.data).toEqual({ config: true })
     expect(config.params).toEqual({ request: true })
 
     await client.post('https://laravel.com', { request: true }, {
-        data: { config: true }
+        data: { config: true },
     })
     expect(config.data).toEqual({ request: true, config: true })
 
     await client.patch('https://laravel.com', { request: true }, {
-        data: { config: true }
+        data: { config: true },
     })
     expect(config.data).toEqual({ request: true, config: true })
 
     await client.put('https://laravel.com', { request: true }, {
-        data: { config: true }
+        data: { config: true },
     })
     expect(config.data).toEqual({ request: true, config: true })
 
     await client.delete('https://laravel.com', { request: true }, {
-        data: { config: true }
+        data: { config: true },
     })
     expect(config.data).toEqual({ config: true })
     expect(config.params).toEqual({ request: true })
@@ -591,13 +591,13 @@ it('merges request data with config params for get and delete requests', async (
     })
 
     await client.get('https://laravel.com', { data: true }, {
-        params: { param: true }
+        params: { param: true },
     })
     expect(config.params).toEqual({ data: true, param: true })
     expect(config.data).toBeUndefined()
 
     await client.delete('https://laravel.com', { data: true }, {
-        params: { param: true }
+        params: { param: true },
     })
     expect(config.params).toEqual({ data: true, param: true })
     expect(config.data).toBeUndefined()

--- a/packages/react-inertia/package.json
+++ b/packages/react-inertia/package.json
@@ -22,6 +22,7 @@
     ],
     "scripts": {
         "build": "rm -rf dist && tsc",
+        "typeCheck": "tsc --noEmit",
         "prepublishOnly": "npm run build",
         "version": "npm pkg set dependencies.laravel-precognition=$npm_package_version && npm pkg set dependencies.laravel-precognition-react=$npm_package_version"
     },

--- a/packages/react-inertia/src/index.ts
+++ b/packages/react-inertia/src/index.ts
@@ -133,10 +133,19 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
 
             return form
         },
-        validate(name?: string|NamedInputEvent) {
+        validate(name?: string|NamedInputEvent|ValidationConfig, config?: ValidationConfig) {
             precognitiveForm.setData(transformer.current(inertiaForm.data))
 
-            precognitiveForm.validate(name)
+            if (typeof name === 'object' && !('target' in name)) {
+                config = name
+                name = undefined
+            }
+
+            if (typeof name === 'undefined') {
+                precognitiveForm.validate(config)
+            } else {
+                precognitiveForm.validate(name, config)
+            }
 
             return form
         },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -21,6 +21,7 @@
     ],
     "scripts": {
         "build": "rm -rf dist && tsc",
+        "typeCheck": "tsc --noEmit",
         "prepublishOnly": "npm run build",
         "version": "npm pkg set dependencies.laravel-precognition=$npm_package_version"
     },

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -143,14 +143,19 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
 
             return form
         },
-        validate(name) {
+        validate(name, config) {
+            if (typeof name === 'object' && !('target' in name)) {
+                config = name
+                name = undefined
+            }
+
             if (typeof name === 'undefined') {
-                validator.current!.validate()
+                validator.current!.validate(config)
             } else {
                 // @ts-expect-error
                 name = resolveName(name)
 
-                validator.current!.validate(name, get(payload.current, name))
+                validator.current!.validate(name, get(payload.current, name), config)
             }
 
             return form

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,4 +1,4 @@
-import { Config, NamedInputEvent, Validator } from 'laravel-precognition'
+import { Config, NamedInputEvent, ValidationConfig, Validator } from 'laravel-precognition'
 
 export interface Form<Data extends Record<string, unknown>> {
     processing: boolean,
@@ -11,7 +11,7 @@ export interface Form<Data extends Record<string, unknown>> {
     hasErrors: boolean,
     valid(name: keyof Data): boolean,
     invalid(name: keyof Data): boolean,
-    validate(name?: keyof Data|NamedInputEvent): Form<Data>,
+    validate(name?: keyof Data|NamedInputEvent|ValidationConfig, config?: ValidationConfig): Form<Data>,
     setErrors(errors: Partial<Record<keyof Data, string|string[]>>): Form<Data>
     forgetError(string: keyof Data|NamedInputEvent): Form<Data>
     setValidationTimeout(duration: number): Form<Data>,

--- a/packages/vue-inertia/package.json
+++ b/packages/vue-inertia/package.json
@@ -22,6 +22,7 @@
     ],
     "scripts": {
         "build": "rm -rf dist && tsc",
+        "typeCheck": "tsc --noEmit",
         "prepublishOnly": "npm run build",
         "test": "vitest run",
         "version": "npm pkg set dependencies.laravel-precognition=$npm_package_version && npm pkg set dependencies.laravel-precognition-vue=$npm_package_version"
@@ -39,6 +40,6 @@
     },
     "devDependencies": {
         "typescript": "^5.0.0",
-        "vitest": "^0.31.3"
+        "vitest": "^1.6.0"
     }
 }

--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -115,10 +115,24 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
 
             return form
         },
-        validate(name?: string|NamedInputEvent) {
+        validate(name?: string|NamedInputEvent|ValidationConfig, config?: ValidationConfig) {
             precognitiveForm.setData(transformer(inertiaForm.data()))
 
-            precognitiveForm.validate(name)
+            if (typeof name === 'object' && !('target' in name)) {
+                config = name
+                name = undefined
+            }
+
+            if (typeof config === 'object') {
+                // @ts-expect-error
+                config.onValidationError = config.onValidationError ?? config?.onError
+            }
+
+            if (typeof name === 'undefined') {
+                precognitiveForm.validate(config)
+            } else {
+                precognitiveForm.validate(name, config)
+            }
 
             return form
         },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -21,6 +21,7 @@
     ],
     "scripts": {
         "build": "rm -rf dist && tsc",
+        "typeCheck": "tsc --noEmit",
         "prepublishOnly": "npm run build",
         "version": "npm pkg set dependencies.laravel-precognition=$npm_package_version"
     },

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -34,9 +34,11 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
             form.validating = validator.validating()
         })
         .on('validatedChanged', () => {
+            // @ts-expect-error
             valid.value = validator.valid()
         })
         .on('touchedChanged', () => {
+            // @ts-expect-error
             touched.value = validator.touched()
         })
         .on('errorsChanged', () => {
@@ -45,6 +47,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
             // @ts-expect-error
             form.errors = toSimpleValidationErrors(validator.errors())
 
+            // @ts-expect-error
             valid.value = validator.valid()
         })
 
@@ -103,14 +106,19 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
 
             return form
         },
-        validate(name) {
+        validate(name, config) {
+            if (typeof name === 'object' && !('target' in name)) {
+                config = name
+                name = undefined
+            }
+
             if (typeof name === 'undefined') {
-                validator.validate()
+                validator.validate(config)
             } else {
                 // @ts-expect-error
                 name = resolveName(name)
 
-                validator.validate(name, get(form.data(), name))
+                validator.validate(name, get(form.data(), name), config)
             }
 
             return form

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -1,4 +1,4 @@
-import { Config, NamedInputEvent, Validator } from 'laravel-precognition'
+import { ValidationConfig, Config, NamedInputEvent, Validator } from 'laravel-precognition'
 
 export interface Form<Data extends Record<string, unknown>> {
     processing: boolean,
@@ -11,7 +11,7 @@ export interface Form<Data extends Record<string, unknown>> {
     hasErrors: boolean,
     valid(name: keyof Data): boolean,
     invalid(name: keyof Data): boolean,
-    validate(name?: keyof Data|NamedInputEvent): Data&Form<Data>,
+    validate(name?: (keyof Data|NamedInputEvent)|ValidationConfig, config?: ValidationConfig): Data&Form<Data>,
     setErrors(errors: Partial<Record<keyof Data, string|string[]>>): Data&Form<Data>
     forgetError(string: keyof Data|NamedInputEvent): Data&Form<Data>
     setValidationTimeout(duration: number): Data&Form<Data>,


### PR DESCRIPTION
This PR introduces the ability to respond to individual validation requests via a callback. 

This is the most requested feature of Precognition.

- https://github.com/laravel/precognition/issues/59
- https://github.com/laravel/precognition/issues/56
- https://github.com/laravel/precognition/issues/51
- https://github.com/laravel/precognition/issues/83
- https://github.com/laravel/precognition/issues/47
- https://github.com/laravel/precognition/pull/66
- https://github.com/laravel/precognition/pull/67

The validate method now accepts a second parameter that can accept configuration.

```vue
<TextInput
    v-model="form.name"
    @change="form.validate('name', {
        onSuccess: () => /* ... */,
        onValidationError: () => /* .. */,
    })"
/>
```

This is also useful when building a wizard. You may call `validate` without any input name to and progress to the next page on success or show an alert on failure.

```vue
<Button 
    @click="form.touch(['name', 'email', 'address', 'phone']).validate({
        onSuccess: () => nextPage(),
        onValidationError: () => notify('You have validation errors'),
    })"
>
    Next
</Button>
```

The local configuration options will always overwrite the global configuration (or merge intelligently when applicable).

```js
const form = useForm('post', '/register', { ... }, {
    onFinish: () => console.log('global config'),
})

form.validate()
// global config

form.validate({
    onFinish: () => console.log('local config'),
})
// local config
```