### PR TITLE
Extended original InertiaJS props and method types into PrecognitionFormProps

### DIFF
--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -1,11 +1,47 @@
-import { Config, NamedInputEvent, RequestMethod, SimpleValidationErrors, toSimpleValidationErrors, ValidationConfig, ValidationErrors, resolveUrl, resolveMethod } from 'laravel-precognition'
+import { Config, NamedInputEvent, RequestMethod, SimpleValidationErrors, toSimpleValidationErrors, ValidationConfig, ValidationErrors, resolveUrl, resolveMethod, Validator } from 'laravel-precognition'
 import { useForm as usePrecognitiveForm, client } from 'laravel-precognition-vue'
 import { useForm as useInertiaForm } from '@inertiajs/vue3'
+import { FormDataConvertible, Progress, VisitOptions } from '@inertiajs/core'
+
 import { watchEffect } from 'vue'
 
 export { client }
 
-export const useForm = <Data extends object>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): any => {
+type FormDataType = object;
+
+interface PrecognitionFormProps<TForm extends FormDataType> {
+    validating: boolean,                                                // Patched
+    isDirty: boolean;
+    errors: Partial<Record<keyof TForm, string>>;
+    hasErrors: boolean;
+    processing: boolean;
+    progress: Progress | null;                                          // Patched
+    wasSuccessful: boolean;
+    recentlySuccessful: boolean;
+    data(): TForm;
+    transform(callback: (data: TForm) => object): this;
+    defaults(): this;
+    defaults(field: keyof TForm, value: FormDataConvertible): this;
+    defaults(fields: Partial<TForm>): this;
+    reset(...fields: (keyof TForm)[]): this;
+    clearErrors(...fields: (keyof TForm)[]): this;
+    touched(name: string): boolean,                                     // Patched
+    touch(name: string | string[] | NamedInputEvent): this;             // Patched
+    submit(submitMethod: RequestMethod|Config, submitUrl?: string, submitOptions?: Partial<VisitOptions>): void; // Patched
+    cancel(): void;
+    setErrors(errors: SimpleValidationErrors|ValidationErrors) : this;  // Patched
+    forgetError(name: string|NamedInputEvent): this;                    // Patched
+    setError(field: keyof TForm, value: string): this;                  // Patched
+    validate(name?: string|NamedInputEvent): this;                      // Patched
+    setValidationTimeout(duration: number): this;
+    validateFiles(): this;
+    validator(): Validator;                                             // Patched
+    valid(name: string | NamedInputEvent | string[]): boolean,          // Patched
+    invalid(name: string): boolean,                                     // Patched
+}
+
+
+export const useForm = <Data extends FormDataType>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): PrecognitionFormProps<Data> & Data => {
     /**
      * The Inertia form.
      */
@@ -61,23 +97,22 @@ export const useForm = <Data extends object>(method: RequestMethod|(() => Reques
         },
         valid: precognitiveForm.valid,
         invalid: precognitiveForm.invalid,
-        clearErrors(...names: string[]) {
-            // @ts-expect-error
-            inertiaClearErrors(...names)
+        clearErrors(...fields: (keyof Data)[]) {
+            inertiaClearErrors(...fields)
 
-            if (names.length === 0) {
+            if (fields.length === 0) {
                 precognitiveForm.setErrors({})
             } else {
-                names.forEach(precognitiveForm.forgetError)
+                // @ts-expect-error
+                fields.forEach(precognitiveForm.forgetError)
             }
 
             return form
         },
-        reset(...names: string[]) {
-            // @ts-expect-error
-            inertiaReset(...names)
+        reset(...fields: (keyof Data)[]) {
+            inertiaReset(...fields)
 
-            precognitiveForm.reset(...names)
+            precognitiveForm.reset(...fields as string[])
         },
         setErrors(errors: SimpleValidationErrors|ValidationErrors) {
             precognitiveForm.setErrors(errors)

--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -2,7 +2,6 @@ import { Config, NamedInputEvent, RequestMethod, SimpleValidationErrors, toSimpl
 import { useForm as usePrecognitiveForm, client } from 'laravel-precognition-vue'
 import { useForm as useInertiaForm } from '@inertiajs/vue3'
 import { FormDataConvertible, Progress, VisitOptions } from '@inertiajs/core'
-
 import { watchEffect } from 'vue'
 
 export { client }

--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -62,6 +62,7 @@ export const useForm = <Data extends object>(method: RequestMethod|(() => Reques
         valid: precognitiveForm.valid,
         invalid: precognitiveForm.invalid,
         clearErrors(...names: string[]) {
+            // @ts-expect-error
             inertiaClearErrors(...names)
 
             if (names.length === 0) {
@@ -73,12 +74,12 @@ export const useForm = <Data extends object>(method: RequestMethod|(() => Reques
             return form
         },
         reset(...names: string[]) {
+            // @ts-expect-error
             inertiaReset(...names)
 
             precognitiveForm.reset(...names)
         },
         setErrors(errors: SimpleValidationErrors|ValidationErrors) {
-            // @ts-expect-error
             precognitiveForm.setErrors(errors)
 
             return form
@@ -99,7 +100,7 @@ export const useForm = <Data extends object>(method: RequestMethod|(() => Reques
             return form
         },
         validate(name?: string|NamedInputEvent) {
-            precognitiveForm.setData(inertiaForm.data())
+            precognitiveForm.setData(inertiaForm.data() as Record<string, unknown>)
 
             precognitiveForm.validate(name)
 
@@ -130,7 +131,7 @@ export const useForm = <Data extends object>(method: RequestMethod|(() => Reques
                 ? resolveMethod(method)
                 : submitMethod as RequestMethod
 
-            inertiaSubmit(submitMethod, submitUrl, {
+            inertiaSubmit(submitMethod, submitUrl as string, {
                 ...submitOptions,
                 onError: (errors: SimpleValidationErrors): any => {
                     precognitiveForm.validator().setErrors(errors)

--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -1,7 +1,7 @@
 import { Config, NamedInputEvent, RequestMethod, SimpleValidationErrors, toSimpleValidationErrors, ValidationConfig, ValidationErrors, resolveUrl, resolveMethod, Validator } from 'laravel-precognition'
 import { useForm as usePrecognitiveForm, client } from 'laravel-precognition-vue'
-import { InertiaForm, useForm as useInertiaForm }   from '@inertiajs/vue3'
-import { Progress }                               from '@inertiajs/core'
+import { InertiaForm, useForm as useInertiaForm } from '@inertiajs/vue3'
+import { Progress } from '@inertiajs/core'
 import { watchEffect } from 'vue'
 
 

--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -4,7 +4,6 @@ import { InertiaForm, useForm as useInertiaForm } from '@inertiajs/vue3'
 import { Progress } from '@inertiajs/core'
 import { watchEffect } from 'vue'
 
-
 export { client }
 
 type FormDataType = object;

--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -1,8 +1,9 @@
 import { Config, NamedInputEvent, RequestMethod, SimpleValidationErrors, toSimpleValidationErrors, ValidationConfig, ValidationErrors, resolveUrl, resolveMethod, Validator } from 'laravel-precognition'
-import { useForm as usePrecognitiveForm, client }      from 'laravel-precognition-vue'
-import { InertiaForm, useForm as useInertiaForm }        from '@inertiajs/vue3'
-import { Progress } from '@inertiajs/core'
+import { useForm as usePrecognitiveForm, client } from 'laravel-precognition-vue'
+import { InertiaForm, useForm as useInertiaForm }   from '@inertiajs/vue3'
+import { Progress }                               from '@inertiajs/core'
 import { watchEffect } from 'vue'
+
 
 export { client }
 
@@ -15,7 +16,7 @@ interface FormProps<TForm extends FormDataType> {
     progress: Progress | null;
     valid(name: string | NamedInputEvent | string[]): boolean,
     invalid(name: string): boolean,
-    clearErrors(...fields: (keyof TForm)[]) : this,
+    clearErrors(...names: (keyof TForm)[]) : this,
     reset(...fields: (keyof TForm)[]) : void,
     setErrors(errors: SimpleValidationErrors|ValidationErrors) : this;
     forgetError(name: string|NamedInputEvent): this;
@@ -97,22 +98,22 @@ export const useForm = <Data extends FormDataType>(method: RequestMethod|(() => 
         },
         valid: precognitiveForm.valid,
         invalid: precognitiveForm.invalid,
-        clearErrors(...fields: (keyof Data)[]) {
-            inertiaClearErrors(...fields)
+        clearErrors(...names: (keyof Data)[]) {
+            inertiaClearErrors(...names)
 
-            if (fields.length === 0) {
+            if (names.length === 0) {
                 precognitiveForm.setErrors({})
             } else {
                 // @ts-expect-error
-                fields.forEach(precognitiveForm.forgetError)
+                names.forEach(precognitiveForm.forgetError)
             }
 
             return form
         },
-        reset(...fields: (keyof Data)[]) {
-            inertiaReset(...fields)
+        reset(...names: (keyof Data)[]) {
+            inertiaReset(...names)
 
-            precognitiveForm.reset(...fields as string[])
+            precognitiveForm.reset(...names as string[])
         },
         setErrors(errors: SimpleValidationErrors|ValidationErrors) {
             precognitiveForm.setErrors(errors)
@@ -142,7 +143,8 @@ export const useForm = <Data extends FormDataType>(method: RequestMethod|(() => 
             return form
         },
         validate(name?: string|NamedInputEvent) {
-            precognitiveForm.setData(inertiaForm.data() as Record<string, unknown>)
+            // @ts-expect-error
+            precognitiveForm.setData(transformer(inertiaForm.data()))
 
             precognitiveForm.validate(name)
 
@@ -173,7 +175,7 @@ export const useForm = <Data extends FormDataType>(method: RequestMethod|(() => 
                 ? resolveMethod(method)
                 : submitMethod as RequestMethod
 
-            inertiaSubmit(submitMethod, submitUrl as string, {
+            inertiaSubmit(submitMethod, submitUrl, {
                 ...submitOptions,
                 onError: (errors: SimpleValidationErrors): any => {
                     precognitiveForm.validator().setErrors(errors)

--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -5,7 +5,7 @@ import { watchEffect } from 'vue'
 
 export { client }
 
-export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): any => {
+export const useForm = <Data extends object>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): any => {
     /**
      * The Inertia form.
      */
@@ -14,7 +14,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
     /**
      * The Precognitive form.
      */
-    const precognitiveForm = usePrecognitiveForm(method, url, inputs, config)
+    const precognitiveForm = usePrecognitiveForm(method, url, inputs as Record<string, unknown>, config)
 
     /**
      * Setup event listeners.


### PR DESCRIPTION
I was able to extend original InertiaJS props and methods types into the PrecognitionFormProps, so Typescript linters can provide scope over the original InertiaFormProps.

This method is better that proposed in https://github.com/laravel/precognition/pull/71 because it's not required to wrap methods for InertiaJS.

Advantages:
- It will automatically inherit automatically all methods and props from different InertiaJS versions.
- Easy to maintain, it only requires to write definitions for the resulted object of Precognition "useForm".

