### PR TITLE
[1.x] Ensures precog requests do not interfere with non-precog requests

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -170,6 +170,7 @@ const refreshAbortController = (config: Config): Config => {
         typeof config.fingerprint !== 'string'
         || config.signal
         || config.cancelToken
+        || ! config.precognitive
     ) {
         return config
     }


### PR DESCRIPTION
fixes https://github.com/laravel/precognition/issues/73

The precognition client will always cancel in-flight requests that match a new outgoing request. This is done to ensure that only the latest validation messages are returned and that we don't get out-of-order responses.

For non-Inertia libraries, we also use the client to submit forms. There are rare situations where a validation request can cancel and actual submission request.

This PR ensures that non-precognitive requests are never cancelled by the library - which is the expected behaviour.

This only impacts the non-Inertia flavoured libraries.