### PR TITLE
Fix/add dot notation types to data object

### DIFF
--- a/packages/react-inertia/src/index.ts
+++ b/packages/react-inertia/src/index.ts
@@ -95,6 +95,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
             if (names.length === 0) {
                 precognitiveForm.setErrors({})
             } else {
+                // @ts-expect-error - React Inertia is not typed sufficiently
                 names.forEach(precognitiveForm.forgetError)
             }
 
@@ -103,6 +104,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
         reset(...names: string[]) {
             inertiaReset(...names)
 
+            // @ts-expect-error - React Inertia is not typed sufficiently
             precognitiveForm.reset(...names)
         },
         setErrors(errors: SimpleValidationErrors|ValidationErrors) {
@@ -122,6 +124,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
             return form
         },
         forgetError(name: string|NamedInputEvent) {
+            // @ts-expect-error - Inertia is not typed sufficiently
             precognitiveForm.forgetError(name)
 
             return form
@@ -136,6 +139,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
         validate(name?: string|NamedInputEvent) {
             precognitiveForm.setData(transformer.current(inertiaForm.data))
 
+            // @ts-expect-error - Inertia is not typed sufficiently
             precognitiveForm.validate(name)
 
             return form

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -150,7 +150,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
                 // @ts-expect-error
                 name = resolveName(name)
 
-                validator.current!.validate(name, get(payload.current, name))
+                validator.current!.validate(name, get(payload.current, name!))
             }
 
             return form
@@ -171,7 +171,6 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
             return form
         },
         forgetError(name) {
-            // @ts-expect-error
             validator.current!.forgetError(name)
 
             return form
@@ -184,7 +183,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
 
                 setData(original)
             } else {
-                names.forEach(name => (set(payload.current, name, get(original, name))))
+                names.forEach(name => (set(payload.current, name!, get(original, name!))))
 
                 setData(payload.current)
             }

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -38,9 +38,9 @@ export interface Form<Data extends Record<string, unknown>> {
     hasErrors: boolean,
     valid(name: Paths<Data>): boolean,
     invalid(name: Paths<Data>): boolean,
-    validate(name?: Paths<Data> | NamedInputEvent): Form<Data>,
+    validate(name?: Paths<Data> | keyof NamedInputEvent): Form<Data>,
     setErrors(errors: Partial<Record<Paths<Data>, string | string[]>>): Form<Data>
-    forgetError(string: Paths<Data> | NamedInputEvent): Form<Data>
+    forgetError(string: Paths<Data> | keyof NamedInputEvent): Form<Data>
     setValidationTimeout(duration: number): Form<Data>,
     submit(config?: Config): Promise<unknown>,
     reset(...names: (Paths<Partial<Data>>)[]): Form<Data>,

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,22 +1,49 @@
 import { Config, NamedInputEvent, Validator } from 'laravel-precognition'
 
+type Join<
+    Key,
+    Previous,
+    TKey extends number | string = string
+> = Key extends TKey
+    ? Previous extends TKey
+    ? `${Key}${'' extends Previous ? '' : '.'}${Previous}`
+    : never
+    : never;
+
+type Previous = [never, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...0[]];
+
+type Paths<
+    TEntity,
+    TDepth extends number = 3,
+    TKey extends number | string = string
+> = [TDepth] extends [never]
+    ? never
+    : TEntity extends object
+    ? {
+        [Key in keyof TEntity]-?: Key extends TKey
+        ? `${Key}` | Join<Key, Paths<TEntity[Key], Previous[TDepth]>>
+        : never;
+    }[keyof TEntity]
+    : '';
+
+
 export interface Form<Data extends Record<string, unknown>> {
     processing: boolean,
     validating: boolean,
-    touched(name: keyof Data): boolean,
-    touch(name: string|NamedInputEvent|Array<string>): Form<Data>,
+    touched(name: Paths<Data>): boolean,
+    touch(name: string | NamedInputEvent | Array<string>): Form<Data>,
     data: Data,
-    setData(key: Data|keyof Data, value?: unknown): Form<Data>,
-    errors: Partial<Record<keyof Data, string>>,
+    setData(key: Data | Paths<Data>, value?: unknown): Form<Data>,
+    errors: Partial<Record<Paths<Data>, string>>,
     hasErrors: boolean,
-    valid(name: keyof Data): boolean,
-    invalid(name: keyof Data): boolean,
-    validate(name?: keyof Data|NamedInputEvent): Form<Data>,
-    setErrors(errors: Partial<Record<keyof Data, string|string[]>>): Form<Data>
-    forgetError(string: keyof Data|NamedInputEvent): Form<Data>
+    valid(name: Paths<Data>): boolean,
+    invalid(name: Paths<Data>): boolean,
+    validate(name?: Paths<Data> | NamedInputEvent): Form<Data>,
+    setErrors(errors: Partial<Record<Paths<Data>, string | string[]>>): Form<Data>
+    forgetError(string: Paths<Data> | NamedInputEvent): Form<Data>
     setValidationTimeout(duration: number): Form<Data>,
     submit(config?: Config): Promise<unknown>,
-    reset(...names: (keyof Partial<Data>)[]): Form<Data>,
+    reset(...names: (Paths<Partial<Data>>)[]): Form<Data>,
     validateFiles(): Form<Data>,
     validator(): Validator,
 }


### PR DESCRIPTION
<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Because lodashes get and set are used and the errors in the response for nested fields are based on dot notation, the selectors for these fields can also be in dot notation. This pull request adds support for that notation to the Data interface.