### PR TITLE
[1.x] Removes unused ignore comments

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -34,11 +34,9 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
             form.validating = validator.validating()
         })
         .on('validatedChanged', () => {
-            // @ts-expect-error
             valid.value = validator.valid()
         })
         .on('touchedChanged', () => {
-            // @ts-expect-error
             touched.value = validator.touched()
         })
         .on('errorsChanged', () => {
@@ -47,7 +45,6 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
             // @ts-expect-error
             form.errors = toSimpleValidationErrors(validator.errors())
 
-            // @ts-expect-error
             valid.value = validator.valid()
         })
 


### PR DESCRIPTION
Vue has improved their type system and these ignore comments are no longer valid. Having them in place is breaking the build.