### PR TITLE
[0.5.x] Type `vue-inertia`

### DIFF
--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -1,15 +1,4 @@
-import {
-    Config,
-    NamedInputEvent,
-    RequestMethod,
-    SimpleValidationErrors,
-    toSimpleValidationErrors,
-    ValidationConfig,
-    ValidationErrors,
-    resolveUrl,
-    resolveMethod,
-    Validator,
-} from 'laravel-precognition'
+import { Config, NamedInputEvent, RequestMethod, SimpleValidationErrors, toSimpleValidationErrors, ValidationConfig, ValidationErrors, resolveUrl, resolveMethod, Validator } from 'laravel-precognition'
 import { useForm as usePrecognitiveForm, client } from 'laravel-precognition-vue'
 import { InertiaForm, useForm as useInertiaForm } from '@inertiajs/vue3'
 import { watchEffect } from 'vue'

--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -1,29 +1,10 @@
-import { Config, NamedInputEvent, RequestMethod, SimpleValidationErrors, toSimpleValidationErrors, ValidationConfig, ValidationErrors, resolveUrl, resolveMethod, Validator } from 'laravel-precognition'
+import { Config, NamedInputEvent, RequestMethod, SimpleValidationErrors, toSimpleValidationErrors, ValidationConfig, ValidationErrors, resolveUrl, resolveMethod } from 'laravel-precognition'
 import { useForm as usePrecognitiveForm, client } from 'laravel-precognition-vue'
-import { InertiaForm, useForm as useInertiaForm } from '@inertiajs/vue3'
+import { useForm as useInertiaForm } from '@inertiajs/vue3'
 import { watchEffect } from 'vue'
+import { Form } from './types'
 
 export { client }
-
-type Precognitive<Data extends object> = {
-    validating: boolean
-    touched: (name: keyof Data) => boolean
-    valid: (name: keyof Data) => boolean
-    invalid: (name: keyof Data) => boolean
-    clearErrors(...names: string[]): Form<Data>
-    reset(...names: string[]): void
-    setErrors(errors: SimpleValidationErrors | ValidationErrors): Form<Data>
-    forgetError(name: string | NamedInputEvent): Form<Data>
-    setError(key: any, value?: any): Form<Data>
-    transform(callback: (data: Data) => Record<string, unknown>): Form<Data>
-    validate(name?: string | NamedInputEvent): Form<Data>
-    setValidationTimeout(duration: number): Form<Data>
-    validateFiles(): Form<Data>
-    submit(submitMethod: RequestMethod | Config, submitUrl?: string, submitOptions?: any): void
-    validator(): Validator
-};
-
-export type Form<Data extends object> = InertiaForm<Data> & Precognitive<Data>
 
 export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod|(() => RequestMethod), url: string|(() => string), inputs: Data, config: ValidationConfig = {}): Form<Data> => {
     /**
@@ -91,6 +72,14 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
         },
         valid: precognitiveForm.valid,
         invalid: precognitiveForm.invalid,
+        setData(data: Record<string, unknown>) {
+            Object.keys(data).forEach(input => {
+                // @ts-expect-error
+                form[input] = data[input]
+            })
+
+            return form
+        },
         clearErrors(...names: string[]) {
             inertiaClearErrors(...names)
 
@@ -193,7 +182,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
             })
         },
         validator: precognitiveForm.validator,
-    } as Precognitive<Data>)
+    })
 
     // Due to the nature of `reactive` elements, reactivity is not inherited by
     // the patched Inertia form as we have to destructure the Precog form. We

--- a/packages/vue-inertia/src/types.ts
+++ b/packages/vue-inertia/src/types.ts
@@ -1,0 +1,15 @@
+import { Config, NamedInputEvent, RequestMethod, SimpleValidationErrors, ValidationConfig, ValidationErrors } from 'laravel-precognition'
+import { Form as PrecognitiveForm } from 'laravel-precognition-vue/dist/types'
+import { InertiaForm } from '@inertiajs/vue3'
+
+export type Form<Data extends Record<string, unknown>> = Omit<PrecognitiveForm<Data>, 'setErrors'|'touch'|'forgetError'|'setValidationTimeout'|'submit'|'reset'|'validateFiles'|'setData'|'validate'> & InertiaForm<Data> & {
+    setErrors(errors: SimpleValidationErrors|ValidationErrors): Form<Data>,
+    touch(name: Array<string>|string|NamedInputEvent): Form<Data>,
+    forgetError(string: keyof Data|NamedInputEvent): Data&Form<Data>,
+    setValidationTimeout(duration: number): Data&Form<Data>,
+    submit(submitMethod: RequestMethod|Config, submitUrl?: string, submitOptions?: any): void,
+    reset(...keys: (keyof Partial<Data>)[]): Data&Form<Data>,
+    validateFiles(): Data&Form<Data>,
+    setData(data: Record<string, unknown>): Data&Form<Data>,
+    validate(name?: (keyof Data|NamedInputEvent)|ValidationConfig, config?: ValidationConfig): Data&Form<Data>,
+}

--- a/packages/vue-inertia/src/types.ts
+++ b/packages/vue-inertia/src/types.ts
@@ -2,7 +2,9 @@ import { Config, NamedInputEvent, RequestMethod, SimpleValidationErrors, Validat
 import { Form as PrecognitiveForm } from 'laravel-precognition-vue/dist/types'
 import { InertiaForm } from '@inertiajs/vue3'
 
-export type Form<Data extends Record<string, unknown>> = Omit<PrecognitiveForm<Data>, 'setErrors'|'touch'|'forgetError'|'setValidationTimeout'|'submit'|'reset'|'validateFiles'|'setData'|'validate'> & InertiaForm<Data> & {
+type RedefinedProperties = 'setErrors'|'touch'|'forgetError'|'setValidationTimeout'|'submit'|'reset'|'validateFiles'|'setData'|'validate'
+
+export type Form<Data extends Record<string, unknown>> = Omit<PrecognitiveForm<Data>, RedefinedProperties> & InertiaForm<Data> & {
     setErrors(errors: SimpleValidationErrors|ValidationErrors): Form<Data>,
     touch(name: Array<string>|string|NamedInputEvent): Form<Data>,
     forgetError(string: keyof Data|NamedInputEvent): Data&Form<Data>,

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -17,6 +17,6 @@ export interface Form<Data extends Record<string, unknown>> {
     setValidationTimeout(duration: number): Data&Form<Data>,
     submit(config?: Config): Promise<unknown>,
     reset(...keys: (keyof Partial<Data>)[]): Data&Form<Data>,
-    validateFiles(): Form<Data>,
+    validateFiles(): Data&Form<Data>,
     validator(): Validator,
 }


### PR DESCRIPTION
The `useForm` composable for Inertia has no types.

This PR adds them.

<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
