### PR TITLE
[0.5.x] Handle missing `onError` callback

### DIFF
--- a/packages/react-inertia/src/index.ts
+++ b/packages/react-inertia/src/index.ts
@@ -171,7 +171,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
                 onError: (errors: SimpleValidationErrors): any => {
                     precognitiveForm.validator().setErrors(errors)
 
-                    if (submitOptions!.onError) {
+                    if (submitOptions?.onError) {
                         return submitOptions.onError(errors)
                     }
                 },

--- a/packages/react-inertia/src/index.ts
+++ b/packages/react-inertia/src/index.ts
@@ -160,26 +160,18 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
             return form
         },
         submit(submitMethod: RequestMethod | Config = {}, submitUrl?: string, submitOptions?: any): void {
-            const isPatchedCall = typeof submitMethod !== 'string'
+            if (typeof submitMethod !== 'string') {
+                submitOptions = submitMethod
+                submitUrl = resolveUrl(url)
+                submitMethod = resolveMethod(method)
+            }
 
-            submitOptions = isPatchedCall
-                ? submitMethod
-                : submitOptions
-
-            submitUrl = isPatchedCall
-                ? resolveUrl(url)
-                : submitUrl!
-
-            submitMethod = isPatchedCall
-                ? resolveMethod(method)
-                : submitMethod as RequestMethod
-
-            inertiaSubmit(submitMethod, submitUrl, {
+            inertiaSubmit(submitMethod, submitUrl!, {
                 ...submitOptions,
                 onError: (errors: SimpleValidationErrors): any => {
                     precognitiveForm.validator().setErrors(errors)
 
-                    if (submitOptions.onError) {
+                    if (submitOptions!.onError) {
                         return submitOptions.onError(errors)
                     }
                 },

--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -178,8 +178,8 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
                 onError: (errors: SimpleValidationErrors): void => {
                     precognitiveForm.validator().setErrors(errors)
 
-                    if (submitOptions!.onError) {
-                        return submitOptions!.onError(errors)
+                    if (submitOptions?.onError) {
+                        return submitOptions.onError(errors)
                     }
                 },
             })


### PR DESCRIPTION
fixes https://github.com/laravel/precognition/issues/101

There is a console error written when a submission is done with the Inertia ordered parameters.

This is because we are incorrectly assuming there is a third parameter, which is actually optional.

We now check that the third parameter is defined.