### PR TITLE
[0.5.x] Use `npx concurrently` for `npm run watch` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "packages/alpine"
     ],
     "scripts": {
-        "watch": "npm run watch --workspace=packages/core& npm run watch --workspace=packages/react& npm run watch --workspace=packages/react-inertia& npm run watch --workspace=packages/vue& npm run watch --workspace=packages/vue-inertia& npm run watch --workspace=packages/alpine& wait;",
+        "watch": "npx concurrently \"npm run watch --workspace=packages/core\" \"npm run watch --workspace=packages/react\" \"npm run watch --workspace=packages/react-inertia\" \"npm run watch --workspace=packages/vue\" \"npm run watch --workspace=packages/vue-inertia\" \"npm run watch --workspace=packages/alpine\" --names=core,react,react-inertia,vue,vue-inertia,alpine",
         "build": "npm run build --workspaces",
         "link": "npm link --workspaces",
         "typeCheck": "npm run typeCheck --workspaces",


### PR DESCRIPTION
Small quality of life improvement while developing and running `npm run watch` across all packages.

Previously was using bash background jobs.