### PR TITLE
[0.5.x] Re-work on-change validation

### DIFF
--- a/packages/alpine/package.json
+++ b/packages/alpine/package.json
@@ -20,7 +20,7 @@
         "/dist"
     ],
     "scripts": {
-        "watch": "rm -rf dist && tsc --watch",
+        "watch": "rm -rf dist && tsc --watch --preserveWatchOutput",
         "build": "rm -rf dist && tsc",
         "typeCheck": "tsc --noEmit",
         "prepublishOnly": "npm run build",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
         "/dist"
     ],
     "scripts": {
-        "watch": "rm -rf dist && tsc --watch",
+        "watch": "rm -rf dist && tsc --watch --preserveWatchOutput",
         "build": "rm -rf dist && tsc",
         "typeCheck": "tsc --noEmit",
         "prepublishOnly": "npm run build",

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -254,11 +254,7 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
                     : response
             },
             onBefore: () => {
-                const beforeValidationHandler = config.onBeforeValidation ?? ((newRequest, oldRequest) => {
-                    return newRequest.touched.length > 0 && ! isEqual(newRequest, oldRequest)
-                })
-
-                if (beforeValidationHandler({ data, touched }, { data: oldData, touched: oldTouched }) === false) {
+                if (config.onBeforeValidation && config.onBeforeValidation({ data, touched }, { data: oldData, touched: oldTouched }) === false) {
                     return false
                 }
 
@@ -313,9 +309,9 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
 
         if (get(oldData, name) !== value) {
             setTouched([name, ...touched]).forEach((listener) => listener())
-        }
 
-        validator(config ?? {})
+            validator(config ?? {})
+        }
     }
 
     /**

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -294,6 +294,8 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
      */
     const validate = (name?: string | NamedInputEvent, value?: unknown, config?: ValidationConfig): void => {
         if (typeof name === 'undefined') {
+            // validator.cancel()
+
             validator(config ?? {})
 
             return

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -169,7 +169,7 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
     /**
      * Create a debounced validation callback.
      */
-    const createValidator = () => debounce((instanceConfig: Config) => {
+    const createValidator = () => debounce((instanceConfig: ValidationConfig) => {
         callback({
             get: (url, data = {}, globalConfig = {}) => client.get(url, parseData(data), resolveConfig(globalConfig, instanceConfig, data)),
             post: (url, data = {}, globalConfig = {}) => client.post(url, parseData(data), resolveConfig(globalConfig, instanceConfig, data)),
@@ -296,7 +296,7 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
     /**
      * Validate the given input.
      */
-    const validate = (name?: string | NamedInputEvent, value?: unknown, config?: Config): void => {
+    const validate = (name?: string | NamedInputEvent, value?: unknown, config?: ValidationConfig): void => {
         if (typeof name === 'undefined') {
             validator(config ?? {})
 

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -294,8 +294,6 @@ export const createValidator = (callback: ValidationCallback, initialData: Recor
      */
     const validate = (name?: string | NamedInputEvent, value?: unknown, config?: ValidationConfig): void => {
         if (typeof name === 'undefined') {
-            // validator.cancel()
-
             validator(config ?? {})
 
             return

--- a/packages/core/tests/validator.test.js
+++ b/packages/core/tests/validator.test.js
@@ -105,17 +105,17 @@ it('does not revalidate data when data is unchanged', async () => {
     expect(requests).toBe(0)
 
     data = { first: true }
-    validator.validate('name', true)
+    validator.validate('first', true)
     expect(requests).toBe(1)
     await vi.advanceTimersByTimeAsync(1500)
 
     data = { first: true }
-    validator.validate('name', true)
+    validator.validate('first', true)
     expect(requests).toBe(1)
     await vi.advanceTimersByTimeAsync(1500)
 
     data = { second: true }
-    validator.validate('name', true)
+    validator.validate('second', true)
     expect(requests).toBe(2)
     await vi.advanceTimersByTimeAsync(1500)
 })
@@ -245,8 +245,6 @@ it('does not validate if the field has not been changed', async () => {
     validator.validate('name', 'Tim')
 
     expect(requestMade).toBe(false)
-
-    await assertPendingValidateDebounceAndClear()
 })
 
 it('filters out files', async () => {

--- a/packages/react-inertia/package.json
+++ b/packages/react-inertia/package.json
@@ -21,7 +21,7 @@
         "/dist"
     ],
     "scripts": {
-        "watch": "rm -rf dist && tsc --watch",
+        "watch": "rm -rf dist && tsc --watch --preserveWatchOutput",
         "build": "rm -rf dist && tsc",
         "typeCheck": "tsc --noEmit",
         "prepublishOnly": "npm run build",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -20,7 +20,7 @@
         "/dist"
     ],
     "scripts": {
-        "watch": "rm -rf dist && tsc --watch",
+        "watch": "rm -rf dist && tsc --watch --preserveWatchOutput",
         "build": "rm -rf dist && tsc",
         "typeCheck": "tsc --noEmit",
         "prepublishOnly": "npm run build",

--- a/packages/vue-inertia/package.json
+++ b/packages/vue-inertia/package.json
@@ -21,7 +21,7 @@
         "/dist"
     ],
     "scripts": {
-        "watch": "rm -rf dist && tsc --watch",
+        "watch": "rm -rf dist && tsc --watch --preserveWatchOutput",
         "build": "rm -rf dist && tsc",
         "typeCheck": "tsc --noEmit",
         "prepublishOnly": "npm run build",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -20,7 +20,7 @@
         "/dist"
     ],
     "scripts": {
-        "watch": "rm -rf dist && tsc --watch",
+        "watch": "rm -rf dist && tsc --watch --preserveWatchOutput",
         "build": "rm -rf dist && tsc",
         "typeCheck": "tsc --noEmit",
         "prepublishOnly": "npm run build",


### PR DESCRIPTION
Precognition does its best to avoid sending requests when it does not need to. This might happen when the validation function has been called but the form's has not changed since the last validation attempt.

You could imagine a text input where the user changes a value and before leaving the field restores the original value. In that scenario there is no need to send a validation request as the form has not changed and the existing validation errors etc still makes sense.

This is the expected behaviour when you are validating a single field and the user is implicitly invoking the `validate` function.

```vue
<input
   v-model="form.email"
   @change="form.validate('name')"
>
```

However, when building a wizard and calling `form.validate()` in a button without specifying a particular input to validate, you expect that the validation process will occur regardless of the state of the form so you are able to react to the response.

```vue
<button
    type="button"
    @click="form.touch(['name', 'email', 'phone']).validate({
        only: ['name', 'email', 'phone'],
        onSuccess: (response) => nextStep(),
        onValidationError: (response) => /* ... */,
    })"
>Next Step</button>
```

The changes in this PR ensure the second scenario will send a validation request even when the form has not changed since the last validation attempt.