### PR TITLE
[0.5.x] Improve async validation API

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -123,24 +123,28 @@ const request = (userConfig: Config = {}): Promise<unknown> => {
 /**
  * Resolve the configuration.
  */
-const resolveConfig = (config: Config): Config => ({
-    ...config,
-    timeout: config.timeout ?? axiosClient.defaults['timeout'] ?? 30000,
-    precognitive: config.precognitive !== false,
-    fingerprint: typeof config.fingerprint === 'undefined'
-        ? requestFingerprintResolver(config, axiosClient)
-        : config.fingerprint,
-    headers: {
-        ...config.headers,
-        'Content-Type': resolveContentType(config),
-        ...config.precognitive !== false ? {
-            Precognition: true,
-        } : {},
-        ...config.validate ? {
-            'Precognition-Validate-Only': Array.from(config.validate).join(),
-        } : {},
-    },
-})
+const resolveConfig = (config: Config): Config => {
+    const only = config.only ?? config.validate
+
+    return {
+        ...config,
+        timeout: config.timeout ?? axiosClient.defaults['timeout'] ?? 30000,
+        precognitive: config.precognitive !== false,
+        fingerprint: typeof config.fingerprint === 'undefined'
+            ? requestFingerprintResolver(config, axiosClient)
+            : config.fingerprint,
+        headers: {
+            ...config.headers,
+            'Content-Type': resolveContentType(config),
+            ...config.precognitive !== false ? {
+                Precognition: true,
+            } : {},
+            ...only ? {
+                'Precognition-Validate-Only': Array.from(only).join(),
+            } : {},
+        },
+    }
+}
 
 /**
  * Determine if the status is successful.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -8,7 +8,9 @@ export type SimpleValidationErrors = Record<string, string>
 
 export type Config = AxiosRequestConfig & {
     precognitive?: boolean,
+    /** @deprecated Use `only` instead */
     validate?: Iterable<string> | ArrayLike<string>,
+    only?: Iterable<string> | ArrayLike<string>,
     fingerprint?: string | null,
     onBefore?: () => boolean | undefined,
     onStart?: () => void,

--- a/packages/core/tests/client.test.js
+++ b/packages/core/tests/client.test.js
@@ -188,6 +188,22 @@ it('can provide input names to validate via config', async () => {
     })
 
     await client.get('https://laravel.com', {}, {
+        only: ['username', 'email'],
+    })
+
+    expect(config.headers['Precognition-Validate-Only']).toBe('username,email')
+})
+
+it('continues to support the deprecated "validate" key as fallback of "only"', async () => {
+    expect.assertions(1)
+
+    let config
+    axios.request.mockImplementationOnce((c) => {
+        config = c
+        return Promise.resolve({ headers: { precognition: 'true' } })
+    })
+
+    await client.get('https://laravel.com', {}, {
         validate: ['username', 'email'],
     })
 


### PR DESCRIPTION
The API when working with a form wizard is less than ideal. We have done a lot of work recently to make this experience better, but the API never felt right.

You currently need to call the `touch` method to ensure the current page's inputs are validated. Inputs are marked as touch when a user interacts with them, but in a wizard you need to validate chunks of the form at a time even if the user has not interacted with the inputs.

```jsx
<button
    onClick={() => form.touch(['name', 'email']).validate({
        onSuccess: () => nextStep(),
    })}
>
    Next Step
</button>
```

It is also not possible to un-touch an input, which can cause issues with certain form wizard configurations where you hide old inputs.

This PR intends to make the wizard API better while addressing the issue with not being able to un-touch inputs.

To achieve this we are exposing an `only` validation key as part of the documented public API. This configuration value already exists, but it is currently called `validate` and is not intended for public use.

I'm renaming the key to `only` now that it is public, which makes it a more expected API name in the Laravel ecosystem. I've depreciated `validate` but kept support for it in case people have been using it.

```jsx
<button
    onClick={() => form.validate({
        only: ['name', 'email'],
        onSuccess: () => nextStep(),
    })}
>
    Next Step
</button>
```

When specifying inputs in the `only` key, validation will only apply to those inputs. Those keys will also be "touched" to ensure their future validation behaviour is expected, including conditional and interdependent validation rules.