### PR TITLE
[0.6.x] Typescript return type for React Inertia useForm()

### DIFF
--- a/packages/react-inertia/src/index.ts
+++ b/packages/react-inertia/src/index.ts
@@ -5,6 +5,8 @@ import { useRef } from 'react'
 import { Form } from './types'
 import { FormDataConvertible } from './types'
 
+export { client }
+
 export const useForm = <Data extends Record<string, FormDataConvertible>>(method: RequestMethod | (() => RequestMethod), url: string | (() => string), inputs: Data, config: ValidationConfig = {}): Form<Data> => {
     const booted = useRef<boolean>(false)
 

--- a/packages/react-inertia/src/index.ts
+++ b/packages/react-inertia/src/index.ts
@@ -2,10 +2,11 @@ import { Config, NamedInputEvent, RequestMethod, SimpleValidationErrors, toSimpl
 import { useForm as usePrecognitiveForm, client } from 'laravel-precognition-react'
 import { useForm as useInertiaForm } from '@inertiajs/react'
 import { useRef } from 'react'
+import { Form } from './types'
 
 export { client }
 
-export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod | (() => RequestMethod), url: string | (() => string), inputs: Data, config: ValidationConfig = {}): any => {
+export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod | (() => RequestMethod), url: string | (() => string), inputs: Data, config: ValidationConfig = {}): Form<Data> => {
     const booted = useRef<boolean>(false)
 
     /**

--- a/packages/react-inertia/src/index.ts
+++ b/packages/react-inertia/src/index.ts
@@ -2,8 +2,7 @@ import { Config, NamedInputEvent, RequestMethod, SimpleValidationErrors, toSimpl
 import { useForm as usePrecognitiveForm, client } from 'laravel-precognition-react'
 import { useForm as useInertiaForm } from '@inertiajs/react'
 import { useRef } from 'react'
-import { Form } from './types'
-import { FormDataConvertible } from './types'
+import { Form, FormDataConvertible } from './types'
 
 export { client }
 

--- a/packages/react-inertia/src/index.ts
+++ b/packages/react-inertia/src/index.ts
@@ -1,6 +1,7 @@
-import { Config, NamedInputEvent, RequestMethod, SimpleValidationErrors, toSimpleValidationErrors, ValidationConfig, ValidationErrors, resolveUrl, resolveMethod } from 'laravel-precognition'
+import { NamedInputEvent, RequestMethod, SimpleValidationErrors, toSimpleValidationErrors, ValidationConfig, ValidationErrors, resolveUrl, resolveMethod } from 'laravel-precognition'
 import { useForm as usePrecognitiveForm, client } from 'laravel-precognition-react'
 import { useForm as useInertiaForm } from '@inertiajs/react'
+import { VisitOptions } from '@inertiajs/core'
 import { useRef } from 'react'
 import { Form, FormDataConvertible } from './types'
 
@@ -160,7 +161,7 @@ export const useForm = <Data extends Record<string, FormDataConvertible>>(method
 
             return form
         },
-        submit(submitMethod: RequestMethod | Config = {}, submitUrl?: string, submitOptions?: any): void {
+        submit(submitMethod: RequestMethod | Partial<VisitOptions> = {}, submitUrl?: string, submitOptions?: Partial<VisitOptions>): void {
             if (typeof submitMethod !== 'string') {
                 submitOptions = submitMethod
                 submitUrl = resolveUrl(url)

--- a/packages/react-inertia/src/types.ts
+++ b/packages/react-inertia/src/types.ts
@@ -5,7 +5,7 @@ import { VisitOptions } from '@inertiajs/core'
 
 type RedefinedProperties = 'setErrors' | 'touch' | 'forgetError' | 'setValidationTimeout' | 'submit' | 'reset' | 'validateFiles' | 'setData' | 'validate'
 
-export type Form<Data extends Record<string, unknown>> = Omit<PrecognitiveForm<Data>, RedefinedProperties> & InertiaFormProps<Data> & {
+export type Form<Data extends Record<string, FormDataConvertible>> = Omit<PrecognitiveForm<Data>, RedefinedProperties> & InertiaFormProps<Data> & {
     setErrors(errors: SimpleValidationErrors | ValidationErrors): Data & Form<Data>,
     touch(name: Array<string> | string | NamedInputEvent): Data & Form<Data>,
     forgetError(string: keyof Data | NamedInputEvent): Data & Form<Data>,
@@ -14,7 +14,7 @@ export type Form<Data extends Record<string, unknown>> = Omit<PrecognitiveForm<D
     submit(method: RequestMethod, url: string, options?: Partial<VisitOptions>): void,
     reset(...keys: (keyof Partial<Data>)[]): Data & Form<Data>,
     validateFiles(): Data & Form<Data>,
-    setData(data: Record<string, unknown>): Data & Form<Data>,
+    setData(data: Record<string, FormDataConvertible>): Data & Form<Data>,
     validate(name?: (keyof Data | NamedInputEvent) | ValidationConfig, config?: ValidationConfig): Data & Form<Data>,
 }
 

--- a/packages/react-inertia/src/types.ts
+++ b/packages/react-inertia/src/types.ts
@@ -11,7 +11,7 @@ export type Form<Data extends Record<string, FormDataConvertible>> = Omit<Precog
     forgetError(string: keyof Data | NamedInputEvent): Form<Data>,
     setValidationTimeout(duration: number): Form<Data>,
     submit(config?: Partial<VisitOptions>): void,
-    submit(method: RequestMethod, url: string, options?: Partial<VisitOptions>): void,
+    submit(method: RequestMethod, url: string, options?: Omit<VisitOptions, 'data'>): void,
     reset(...keys: (keyof Partial<Data>)[]): void,
     validateFiles(): Form<Data>,
     setData(data: Record<string, FormDataConvertible>): Form<Data>,

--- a/packages/react-inertia/src/types.ts
+++ b/packages/react-inertia/src/types.ts
@@ -6,16 +6,16 @@ import { VisitOptions } from '@inertiajs/core'
 type RedefinedProperties = 'setErrors' | 'touch' | 'forgetError' | 'setValidationTimeout' | 'submit' | 'reset' | 'validateFiles' | 'setData' | 'validate'
 
 export type Form<Data extends Record<string, FormDataConvertible>> = Omit<PrecognitiveForm<Data>, RedefinedProperties> & InertiaFormProps<Data> & {
-    setErrors(errors: SimpleValidationErrors | ValidationErrors): Data & Form<Data>,
-    touch(name: Array<string> | string | NamedInputEvent): Data & Form<Data>,
-    forgetError(string: keyof Data | NamedInputEvent): Data & Form<Data>,
-    setValidationTimeout(duration: number): Data & Form<Data>,
+    setErrors(errors: SimpleValidationErrors | ValidationErrors): Form<Data>,
+    touch(name: Array<string> | string | NamedInputEvent): Form<Data>,
+    forgetError(string: keyof Data | NamedInputEvent): Form<Data>,
+    setValidationTimeout(duration: number): Form<Data>,
     submit(config?: Partial<VisitOptions>): void,
     submit(method: RequestMethod, url: string, options?: Partial<VisitOptions>): void,
-    reset(...keys: (keyof Partial<Data>)[]): Data & Form<Data>,
-    validateFiles(): Data & Form<Data>,
-    setData(data: Record<string, FormDataConvertible>): Data & Form<Data>,
-    validate(name?: (keyof Data | NamedInputEvent) | ValidationConfig, config?: ValidationConfig): Data & Form<Data>,
+    reset(...keys: (keyof Partial<Data>)[]): void,
+    validateFiles(): Form<Data>,
+    setData(data: Record<string, FormDataConvertible>): Form<Data>,
+    validate(name?: (keyof Data | NamedInputEvent) | ValidationConfig, config?: ValidationConfig): Form<Data>,
 }
 
 // This type has been duplicated from @inertiajs/core to

--- a/packages/react-inertia/src/types.ts
+++ b/packages/react-inertia/src/types.ts
@@ -1,0 +1,19 @@
+import { NamedInputEvent, RequestMethod, SimpleValidationErrors, ValidationConfig, ValidationErrors } from 'laravel-precognition'
+import { Form as PrecognitiveForm } from 'laravel-precognition-react/dist/types'
+import { InertiaFormProps } from '@inertiajs/react'
+import { VisitOptions } from '@inertiajs/core'
+
+type RedefinedProperties = 'setErrors' | 'touch' | 'forgetError' | 'setValidationTimeout' | 'submit' | 'reset' | 'validateFiles' | 'setData' | 'validate'
+
+export type Form<Data extends Record<string, unknown>> = Omit<PrecognitiveForm<Data>, RedefinedProperties> & InertiaFormProps<Data> & {
+    setErrors(errors: SimpleValidationErrors | ValidationErrors): Data & Form<Data>,
+    touch(name: Array<string> | string | NamedInputEvent): Data & Form<Data>,
+    forgetError(string: keyof Data | NamedInputEvent): Data & Form<Data>,
+    setValidationTimeout(duration: number): Data & Form<Data>,
+    submit(config?: Partial<VisitOptions>): void,
+    submit(method: RequestMethod, url: string, options?: Partial<VisitOptions>): void,
+    reset(...keys: (keyof Partial<Data>)[]): Data & Form<Data>,
+    validateFiles(): Data & Form<Data>,
+    setData(data: Record<string, unknown>): Data & Form<Data>,
+    validate(name?: (keyof Data | NamedInputEvent) | ValidationConfig, config?: ValidationConfig): Data & Form<Data>,
+}


### PR DESCRIPTION
The React Inertia useForm() hook is typed to return `any`, but we can improve this by returning `Form<Data>`, similar to the React Vue plugin.

However, there's no types.ts file in the `react-inertia` package, though the file exists in the `vue-inertia` package.

https://github.com/laravel/precognition/tree/main/packages/react-inertia/src
https://github.com/laravel/precognition/tree/main/packages/vue-inertia/src

I copied the types.ts file from vue-inertia, modified it with the correct imports, and updated the useForm() return type.