### PR TITLE
[0.5.x] Improve native browser submission while disabling formset on submit

### DIFF
--- a/packages/alpine/src/index.ts
+++ b/packages/alpine/src/index.ts
@@ -165,7 +165,7 @@ export default function (Alpine: TAlpine) {
          */
         const form = Alpine.reactive(createForm()) as Data & Form<Data>
 
-        syncWithDom(el, resolveMethod(method), resolveUrl(url), form)
+        syncWithDom(Alpine, el, resolveMethod(method), resolveUrl(url), form)
 
         return form
     })
@@ -174,7 +174,7 @@ export default function (Alpine: TAlpine) {
 /**
  * Sync the DOM form with the Precognitive form.
  */
-const syncWithDom = <Data extends Record<string, unknown>>(el: Node, method: RequestMethod, url: string, form: Form<Data>): void => {
+const syncWithDom = <Data extends Record<string, unknown>>(Alpine: TAlpine, el: Node, method: RequestMethod, url: string, form: Form<Data>): void => {
     if (! (el instanceof Element && el.nodeName === 'FORM')) {
         return
     }
@@ -182,7 +182,7 @@ const syncWithDom = <Data extends Record<string, unknown>>(el: Node, method: Req
     syncSyntheticMethodInput(el, method)
     syncMethodAttribute(el, method)
     syncActionAttribute(el, url)
-    addProcessingListener(el, form)
+    addProcessingListener(Alpine, el, form)
 }
 
 /**
@@ -231,4 +231,6 @@ const syncSyntheticMethodInput = (el: Element, method: RequestMethod) => {
 /**
  * Add processing listener.
  */
-const addProcessingListener = <Data extends Record<string, unknown>>(el: Element, form: Form<Data>) => el.addEventListener('submit', () => (form.processing = true))
+const addProcessingListener = <Data extends Record<string, unknown>>(Alpine: TAlpine, el: Element, form: Form<Data>) => el.addEventListener('submit', () => {
+    Alpine.nextTick(() => form.processing = true)
+})


### PR DESCRIPTION
When using the Alpine library, it is common to continue using native browser form submissions.

A common pattern is to disable inputs on submit via a `fieldset` group.

```html
<form
    x-data="{
        form: $form('post', '/register', {
            name: ''
        }),
    }"
>
    <fieldset
        x-bind:disabled="form.processing"
    >
        <input
            name="name"
            x-model="form.name"
            @change="form.validate('name')"
        >
    </fieldset>
    <button>Submit</button>
</form>
```

When we detect a native browser submission, via the `formElement.addEventListener('submit')` listener, we set `processing = true`, however because the event listener triggers before the browser has actually sent the request it disables the inputs BEFORE the submission and the form inputs are not sent to the browser.

Browsers do not submit disabled inputs.


<img width="820" alt="Screenshot 2024-12-17 at 10 30 57" src="https://github.com/user-attachments/assets/80e56888-6bb8-4e01-91e8-5796dc4ded99" />

Source: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled#usability

This PR delays setting `processing = true` until after the current tick to ensure inputs are sent before the form becomes delayed.

fixes https://github.com/laravel/precognition/issues/100