### PR TITLE
[0.6.x]: Data Getter Support in vue and vue-inertia Forms

### DIFF
--- a/packages/vue-inertia/src/index.ts
+++ b/packages/vue-inertia/src/index.ts
@@ -7,7 +7,7 @@ import { Form } from './types'
 
 export { client }
 
-export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod | (() => RequestMethod), url: string | (() => string), inputs: Data, config: ValidationConfig = {}): Form<Data> => {
+export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod | (() => RequestMethod), url: string | (() => string), inputs: Data | (() => Data), config: ValidationConfig = {}): Form<Data> => {
     /**
      * The Inertia form.
      */

--- a/packages/vue-inertia/tests/index.test.ts
+++ b/packages/vue-inertia/tests/index.test.ts
@@ -111,3 +111,22 @@ it('can set individual errors', function () {
 
     expect(form.errors.name).toBe('The name is required.')
 })
+
+it('allows getter as data inputs', function () {
+    let dynamicEmail = 'taylor@laravel.com'
+
+    function getData() {
+        return {
+            email: dynamicEmail,
+        }
+    }
+
+    const form = useForm('post', '/register', getData)
+
+    expect(form.email).toBe('taylor@laravel.com')
+
+    dynamicEmail = 'tim@laravel.com'
+    form.reset()
+
+    expect(form.email).toBe('tim@laravel.com')
+})

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -5,11 +5,11 @@ import { cloneDeep, get, set } from 'lodash-es'
 
 export { client }
 
-export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod | (() => RequestMethod), url: string | (() => string), inputs: Data, config: ValidationConfig = {}): Data & Form<Data> => {
+export const useForm = <Data extends Record<string, unknown>>(method: RequestMethod | (() => RequestMethod), url: string | (() => string), inputs: Data | (() => Data), config: ValidationConfig = {}): Data & Form<Data> => {
     /**
      * The original data.
      */
-    const originalData = cloneDeep(inputs)
+    const originalData = typeof inputs === 'function' ? cloneDeep(inputs()) : cloneDeep(inputs)
 
     /**
      * The original input names.
@@ -143,7 +143,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
             return form
         },
         reset(...names) {
-            const original = cloneDeep(originalData)
+            const original = typeof inputs === 'function' ? cloneDeep(inputs()) : cloneDeep(originalData)
 
             if (names.length === 0) {
                 // @ts-expect-error


### PR DESCRIPTION
This PR adds support for inputs data getter in vue and vue-inertia Forms. 
It's mirroring the functionality of `@inertiajs/vue3`'s `useForm`.

### Example usage :

```ts
let dynamicEmail = 'taylor@laravel.com'
function getData() {
  return { email: dynamicEmail }
}
const form = useForm('post', '/register', getData) 
```