### PR TITLE
Add Svelte 5 and Svelte Inertia

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
         "packages/react-inertia",
         "packages/vue",
         "packages/vue-inertia",
-        "packages/alpine"
+        "packages/alpine",
+        "packages/svelte"
     ],
     "scripts": {
-        "watch": "npx concurrently \"npm run watch --workspace=packages/core\" \"npm run watch --workspace=packages/react\" \"npm run watch --workspace=packages/react-inertia\" \"npm run watch --workspace=packages/vue\" \"npm run watch --workspace=packages/vue-inertia\" \"npm run watch --workspace=packages/alpine\" --names=core,react,react-inertia,vue,vue-inertia,alpine",
+        "watch": "npx concurrently \"npm run watch --workspace=packages/core\" \"npm run watch --workspace=packages/react\" \"npm run watch --workspace=packages/react-inertia\" \"npm run watch --workspace=packages/vue\" \"npm run watch --workspace=packages/vue-inertia\" \"npm run watch --workspace=packages/alpine\" \"npm run watch --workspace=packages/svelte\" --names=core,react,react-inertia,vue,vue-inertia,alpine,svelte",
         "build": "npm run build --workspaces",
         "link": "npm link --workspaces",
         "typeCheck": "npm run typeCheck --workspaces",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
         "packages/vue",
         "packages/vue-inertia",
         "packages/alpine",
-        "packages/svelte"
+        "packages/svelte",
+        "packages/svelte-inertia"
     ],
     "scripts": {
-        "watch": "npx concurrently \"npm run watch --workspace=packages/core\" \"npm run watch --workspace=packages/react\" \"npm run watch --workspace=packages/react-inertia\" \"npm run watch --workspace=packages/vue\" \"npm run watch --workspace=packages/vue-inertia\" \"npm run watch --workspace=packages/alpine\" \"npm run watch --workspace=packages/svelte\" --names=core,react,react-inertia,vue,vue-inertia,alpine,svelte",
+        "watch": "npx concurrently \"npm run watch --workspace=packages/core\" \"npm run watch --workspace=packages/react\" \"npm run watch --workspace=packages/react-inertia\" \"npm run watch --workspace=packages/vue\" \"npm run watch --workspace=packages/vue-inertia\" \"npm run watch --workspace=packages/alpine\" \"npm run watch --workspace=packages/svelte\" \"npm run watch --workspace=packages/svelte-inertia\" --names=core,react,react-inertia,vue,vue-inertia,alpine,svelte,svelte-inertia",
         "build": "npm run build --workspaces",
         "link": "npm link --workspaces",
         "typeCheck": "npm run typeCheck --workspaces",

--- a/packages/svelte-inertia/.gitignore
+++ b/packages/svelte-inertia/.gitignore
@@ -1,0 +1,2 @@
+/dist
+/node_modules

--- a/packages/svelte-inertia/LICENSE.md
+++ b/packages/svelte-inertia/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Taylor Otwell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/svelte-inertia/README.md
+++ b/packages/svelte-inertia/README.md
@@ -1,0 +1,31 @@
+# Laravel Precognition
+
+<a href="https://github.com/laravel/precognition/actions"><img src="https://github.com/laravel/precognition/workflows/tests/badge.svg" alt="Test Status"></a>
+<a href="https://github.com/laravel/precognition/actions"><img src="https://github.com/laravel/precognition/workflows/build/badge.svg" alt="Build Status"></a>
+<a href="https://www.npmjs.com/package/laravel-precognition"><img src="https://img.shields.io/npm/dt/laravel-precognition" alt="Total Downloads"></a>
+<a href="https://www.npmjs.com/package/laravel-precognition"><img src="https://img.shields.io/npm/v/laravel-precognition" alt="Latest Stable Version"></a>
+<a href="https://www.npmjs.com/package/laravel-precognition"><img src="https://img.shields.io/npm/l/laravel-precognition" alt="License"></a>
+
+## Introduction
+
+Laravel Precognition allows you to anticipate the outcome of a future HTTP request. One of the primary use cases of Precognition is the ability to provide "live" validation in your frontend application.
+
+## Official Documentation
+
+Documentation for Laravel Precognition can be found on the [Laravel website](https://laravel.com/docs/precognition).
+
+## Contributing
+
+Thank you for considering contributing to Laravel Precognition! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
+
+## Code of Conduct
+
+In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).
+
+## Security Vulnerabilities
+
+Please review [our security policy](https://github.com/laravel/precognition/security/policy) on how to report security vulnerabilities.
+
+## License
+
+Laravel Precognition is open-sourced software licensed under the [MIT license](LICENSE.md).

--- a/packages/svelte-inertia/package.json
+++ b/packages/svelte-inertia/package.json
@@ -1,0 +1,53 @@
+{
+    "name": "laravel-precognition-svelte-inertia",
+    "version": "0.0.1",
+    "description": "Laravel Precognition (Svelte w/ Inertia).",
+    "keywords": [
+        "laravel",
+        "precognition",
+        "svelte",
+        "inertia"
+    ],
+    "homepage": "https://github.com/laravel/precognition",
+    "type": "module",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/laravel/precognition"
+    },
+    "license": "MIT",
+    "author": "Laravel",
+    "main": "dist/index.js",
+    "files": [
+        "dist",
+        "!dist/**/*.test.*",
+        "!dist/**/*.spec.*"
+    ],
+    "svelte": "./dist/index.svelte.js",
+    "types": "./dist/index.svelte.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.svelte.d.ts",
+            "svelte": "./dist/index.svelte.js"
+        }
+    },
+    "scripts": {
+        "watch": "rm -rf dist && tsc --watch --preserveWatchOutput",
+        "build": "rm -rf dist && tsc",
+        "typeCheck": "tsc --noEmit",
+        "prepublishOnly": "npm run build",
+        "version": "npm pkg set dependencies.laravel-precognition=$npm_package_version"
+    },
+    "peerDependencies": {
+        "@inertiajs/svelte": "^1.0.0 || ^2.0.0",
+        "svelte": "^5.0.0"
+    },
+    "dependencies": {
+        "laravel-precognition": "0.7.2",
+        "laravel-precognition-svelte": "0.0.1",
+        "lodash-es": "^4.17.21"
+    },
+    "devDependencies": {
+        "@types/lodash-es": "^4.17.12",
+        "typescript": "^5.0.0"
+    }
+}

--- a/packages/svelte-inertia/src/index.svelte.ts
+++ b/packages/svelte-inertia/src/index.svelte.ts
@@ -1,0 +1,185 @@
+import { FormDataConvertible, VisitOptions } from '@inertiajs/core'
+import { useForm as useInertiaForm } from '@inertiajs/svelte'
+import {
+    client,
+    NamedInputEvent,
+    RequestMethod,
+    resolveMethod,
+    resolveUrl,
+    SimpleValidationErrors,
+    toSimpleValidationErrors,
+    ValidationConfig,
+    ValidationErrors,
+} from 'laravel-precognition'
+import { useForm as usePrecognitiveForm } from 'laravel-precognition-svelte'
+import { fromStore, get, writable, Writable } from 'svelte/store'
+import { Form } from './types'
+
+export { client }
+
+export const useForm = <Data extends Record<string, FormDataConvertible>>(
+    method: RequestMethod | (() => RequestMethod),
+    url: string | (() => string),
+    inputs: Data,
+    config: ValidationConfig = {},
+): Writable<Form<Data>> => {
+    /**
+     * The Inertia form.
+     */
+    const inertiaForm = useInertiaForm(inputs)
+
+    /**
+     * The React form.
+     */
+    const precognitiveForm = usePrecognitiveForm(method, url, inputs, config)
+
+    /**
+     * The transform function.
+     */
+    let transformer: (data: Data) => Data = (data) => data
+
+    /**
+     * Patch the form.
+     */
+    const form = writable({
+        ...fromStore(inertiaForm).current,
+        validating: false,
+        touched: precognitiveForm.touched,
+        touch(name: Array<string> | string | NamedInputEvent) {
+            precognitiveForm.touch(name)
+
+            return get(form)
+        },
+        valid: precognitiveForm.valid,
+        invalid: precognitiveForm.invalid,
+        errors: precognitiveForm.errors,
+        clearErrors(...names: string[]) {
+            form.update((prev) => {
+                names.forEach((name) => delete prev.errors[name])
+
+                return prev
+            })
+
+            if (names.length === 0) {
+                precognitiveForm.setErrors({})
+            } else {
+                names.forEach(precognitiveForm.forgetError)
+            }
+
+            return get(form)
+        },
+        reset(...names: string[]) {
+            // inertiaReset(...names)
+
+            precognitiveForm.reset(...names)
+        },
+        setErrors(errors: SimpleValidationErrors | ValidationErrors) {
+            // @ts-ignore
+            precognitiveForm.setErrors(errors)
+
+            return get(form)
+        },
+        setError(key: any, value?: any) {
+            // @ts-ignore
+            form.update((prev) => ({
+                ...prev,
+                errors: { ...prev.errors, ...(typeof value === 'undefined' ? key : { [key]: value }) },
+            }))
+
+            return get(form)
+        },
+        forgetError(name: string | NamedInputEvent) {
+            precognitiveForm.forgetError(name)
+
+            return get(form)
+        },
+        transform(callback: (data: Data) => Data) {
+            form.update((prev) => {
+                prev.transform(callback)
+
+                return prev
+            })
+
+            transformer = callback
+
+            return get(form)
+        },
+        validate(name?: keyof Data | NamedInputEvent | ValidationConfig, config?: ValidationConfig) {
+            precognitiveForm.setData(transformer(get(form).data()))
+
+            if (typeof name === 'object' && !('target' in name)) {
+                config = name
+                name = undefined
+            }
+
+            if (typeof name === 'undefined') {
+                precognitiveForm.validate(config)
+            } else {
+                precognitiveForm.validate(name, config)
+            }
+
+            return get(form)
+        },
+        setValidationTimeout(duration: number) {
+            precognitiveForm.setValidationTimeout(duration)
+
+            return get(form)
+        },
+        validateFiles() {
+            precognitiveForm.validateFiles()
+
+            return get(form)
+        },
+        submit(
+            submitMethod: RequestMethod | Partial<VisitOptions> = {},
+            submitUrl?: string,
+            submitOptions?: Partial<VisitOptions>,
+        ): void {
+            if (typeof submitMethod !== 'string') {
+                submitOptions = submitMethod
+                submitUrl = resolveUrl(url)
+                submitMethod = resolveMethod(method)
+            }
+
+            inertiaForm.update((prev) => ({
+                ...prev,
+                ...get(form).data(),
+            }))
+
+            get(inertiaForm).submit(submitMethod, submitUrl!, {
+                ...submitOptions,
+                onError: (errors: SimpleValidationErrors): any => {
+                    precognitiveForm.validator().setErrors(errors)
+
+                    if (submitOptions?.onError) {
+                        return submitOptions.onError(errors)
+                    }
+                },
+            })
+        },
+        validator: precognitiveForm.validator,
+    })
+
+    /**
+     * Setup event listeners.
+     */
+    form.subscribe((value) => precognitiveForm.setData(value.data()))
+
+    precognitiveForm
+        .validator()
+        .on('errorsChanged', () => {
+            // @ts-ignore
+            form.update((prev) => ({
+                ...prev,
+                errors: toSimpleValidationErrors(precognitiveForm.validator().errors()),
+            }))
+        })
+        .on('validatingChanged', () => {
+            form.update((prev) => ({
+                ...prev,
+                validating: precognitiveForm.validating,
+            }))
+        })
+
+    return form
+}

--- a/packages/svelte-inertia/src/types.ts
+++ b/packages/svelte-inertia/src/types.ts
@@ -1,0 +1,49 @@
+import { VisitOptions } from '@inertiajs/core'
+import { InertiaForm } from '@inertiajs/svelte'
+import {
+    client,
+    RequestMethod,
+    SimpleValidationErrors,
+    ValidationErrors,
+    type NamedInputEvent,
+    type ValidationConfig,
+} from 'laravel-precognition'
+import { Form as PrecognitiveForm } from 'laravel-precognition-svelte/dist/types'
+export { client }
+
+type RedefinedProperties =
+    | 'setErrors'
+    | 'touch'
+    | 'forgetError'
+    | 'setValidationTimeout'
+    | 'submit'
+    | 'reset'
+    | 'validateFiles'
+    | 'setData'
+    | 'validate'
+
+export type Form<Data extends Record<string, FormDataConvertible>> = Omit<PrecognitiveForm<Data>, RedefinedProperties> &
+    Omit<InertiaForm<Data>, RedefinedProperties> & {
+        setErrors(errors: SimpleValidationErrors | ValidationErrors): Form<Data>
+        touch(name: Array<string> | string | NamedInputEvent): Form<Data>
+        forgetError(string: keyof Data | NamedInputEvent): Form<Data>
+        setValidationTimeout(duration: number): Form<Data>
+        submit(config?: Partial<VisitOptions>): void
+        submit(method: RequestMethod, url: string, options?: Omit<VisitOptions, 'data'>): void
+        reset(...keys: (keyof Partial<Data>)[]): void
+        validateFiles(): Form<Data>
+        validate(name?: (keyof Data | NamedInputEvent) | ValidationConfig, config?: ValidationConfig): Form<Data>
+        valid: (name: keyof Data) => boolean
+        invalid: (name: keyof Data) => boolean
+    }
+
+export type FormDataConvertible =
+    | Array<FormDataConvertible>
+    | { [key: string]: FormDataConvertible }
+    | Blob
+    | FormDataEntryValue
+    | Date
+    | boolean
+    | number
+    | null
+    | undefined

--- a/packages/svelte-inertia/tsconfig.json
+++ b/packages/svelte-inertia/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "outDir": "./dist",
+        "target": "ES2020",
+        "module": "ES2020",
+        "moduleResolution": "node",
+        "resolveJsonModule": true,
+        "strict": true,
+        "declaration": true,
+        "esModuleInterop": true
+    },
+    "include": [
+        "./src/index.svelte.ts"
+    ]
+}

--- a/packages/svelte/.gitignore
+++ b/packages/svelte/.gitignore
@@ -1,0 +1,2 @@
+/dist
+/node_modules

--- a/packages/svelte/LICENSE.md
+++ b/packages/svelte/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Taylor Otwell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -1,0 +1,31 @@
+# Laravel Precognition
+
+<a href="https://github.com/laravel/precognition/actions"><img src="https://github.com/laravel/precognition/workflows/tests/badge.svg" alt="Test Status"></a>
+<a href="https://github.com/laravel/precognition/actions"><img src="https://github.com/laravel/precognition/workflows/build/badge.svg" alt="Build Status"></a>
+<a href="https://www.npmjs.com/package/laravel-precognition"><img src="https://img.shields.io/npm/dt/laravel-precognition" alt="Total Downloads"></a>
+<a href="https://www.npmjs.com/package/laravel-precognition"><img src="https://img.shields.io/npm/v/laravel-precognition" alt="Latest Stable Version"></a>
+<a href="https://www.npmjs.com/package/laravel-precognition"><img src="https://img.shields.io/npm/l/laravel-precognition" alt="License"></a>
+
+## Introduction
+
+Laravel Precognition allows you to anticipate the outcome of a future HTTP request. One of the primary use cases of Precognition is the ability to provide "live" validation in your frontend application.
+
+## Official Documentation
+
+Documentation for Laravel Precognition can be found on the [Laravel website](https://laravel.com/docs/precognition).
+
+## Contributing
+
+Thank you for considering contributing to Laravel Precognition! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
+
+## Code of Conduct
+
+In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).
+
+## Security Vulnerabilities
+
+Please review [our security policy](https://github.com/laravel/precognition/security/policy) on how to report security vulnerabilities.
+
+## License
+
+Laravel Precognition is open-sourced software licensed under the [MIT license](LICENSE.md).

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,0 +1,50 @@
+{
+    "name": "laravel-precognition-svelte",
+    "version": "0.0.1",
+    "description": "Laravel Precognition (Svelte).",
+    "keywords": [
+        "laravel",
+        "precognition",
+        "svelte"
+    ],
+    "homepage": "https://github.com/laravel/precognition",
+    "type": "module",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/laravel/precognition"
+    },
+    "license": "MIT",
+    "author": "Laravel",
+    "main": "dist/index.js",
+    "files": [
+        "dist",
+        "!dist/**/*.test.*",
+        "!dist/**/*.spec.*"
+    ],
+    "svelte": "./dist/index.svelte.js",
+    "types": "./dist/index.svelte.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.svelte.d.ts",
+            "svelte": "./dist/index.svelte.js"
+        }
+    },
+    "scripts": {
+        "watch": "rm -rf dist && tsc --watch --preserveWatchOutput",
+        "build": "rm -rf dist && tsc",
+        "typeCheck": "tsc --noEmit",
+        "prepublishOnly": "npm run build",
+        "version": "npm pkg set dependencies.laravel-precognition=$npm_package_version"
+    },
+    "peerDependencies": {
+        "svelte": "^5.0.0"
+    },
+    "dependencies": {
+        "laravel-precognition": "0.7.2",
+        "lodash-es": "^4.17.21"
+    },
+    "devDependencies": {
+        "@types/lodash-es": "^4.17.12",
+        "typescript": "^5.0.0"
+    }
+}

--- a/packages/svelte/src/index.svelte.ts
+++ b/packages/svelte/src/index.svelte.ts
@@ -1,0 +1,228 @@
+import {
+    Config,
+    RequestMethod,
+    ValidationConfig,
+    client,
+    createValidator,
+    resolveMethod,
+    resolveName,
+    resolveUrl,
+    toSimpleValidationErrors,
+} from 'laravel-precognition'
+import { cloneDeep, get, set } from 'lodash-es'
+import { Form } from './types.js'
+
+export { client }
+
+export const useForm = <Data extends Record<string, unknown>>(
+    method: RequestMethod | (() => RequestMethod),
+    url: string | (() => string),
+    inputs: Data,
+    config: ValidationConfig = {},
+): Data & Form<Data> => {
+    /**
+     * The original data.
+     */
+    const originalData = cloneDeep(inputs)
+
+    /**
+     * The original input names.
+     */
+    const originalInputs: (keyof Data)[] = Object.keys(originalData)
+
+    /**
+     * Reactive valid state.
+     */
+    // @ts-ignore
+    let valid = $state<(keyof Data)[]>([])
+
+    /**
+     * Reactive touched state.
+     */
+    // @ts-ignore
+    let touched = $state<(keyof Partial<Data>)[]>([])
+
+    /**
+     * Reactive errors.
+     */
+    // @ts-ignore
+    let errors = $state<Record<keyof Data, any>>({})
+
+    /**
+     * Reactive hasErrors.
+     */
+    // @ts-ignore
+    const hasErrors = $derived<boolean>(Object.keys(errors).length > 0)
+
+    /**
+     * Reactive Validating.
+     */
+    // @ts-ignore
+    let validating = $state<boolean>(false)
+
+    /**
+     * Reactive Processing.
+     */
+    // @ts-ignore
+    let processing = $state<boolean>(false)
+
+    /**
+     * Reactive Data state
+     */
+    // @ts-ignore
+    const data = $state<Data>(cloneDeep(originalData))
+
+    /**
+     * The validator instance.
+     */
+    const validator = createValidator(
+        (client) => client[resolveMethod(method)](resolveUrl(url), form.data(), config),
+        originalData,
+    )
+        .on('validatingChanged', () => {
+            validating = validator.validating()
+        })
+        .on('validatedChanged', () => {
+            valid = validator.valid()
+        })
+        .on('touchedChanged', () => {
+            touched = validator.touched()
+        })
+        .on('errorsChanged', () => {
+            errors = toSimpleValidationErrors(validator.errors()) as Record<keyof Data, any>
+            valid = validator.valid()
+        })
+
+    /**
+     * Resolve the config for a form submission.
+     */
+    const resolveSubmitConfig = (config: Config): Config => ({
+        ...config,
+        precognitive: false,
+        onStart: () => {
+            processing = true
+
+            config.onStart?.()
+        },
+        onFinish: () => {
+            processing = false
+
+            config.onFinish?.()
+        },
+        onValidationError: (response: any, error: any) => {
+            validator.setErrors(response.data.errors)
+
+            return config.onValidationError ? config.onValidationError(response) : Promise.reject(error)
+        },
+    })
+
+    /**
+     * Create a new form instance.
+     */
+    const form: Data & Form<Data> = {
+        ...cloneDeep(originalData),
+        data() {
+            // @ts-ignore
+            return $state.snapshot(data) as Data
+        },
+        setData(newData: Data & Record<string, unknown>) {
+            Object.keys(newData).forEach((input) => {
+                data[input] = newData[input]
+            })
+            return form
+        },
+        touched(name: keyof Data) {
+            return touched.includes(name)
+        },
+        touch(name: keyof Data & string) {
+            validator.touch(name)
+
+            return form
+        },
+        validate(name: keyof Data | undefined, config: Config) {
+            if (typeof name === 'object' && !('target' in name)) {
+                config = name
+                name = undefined
+            }
+
+            if (typeof name === 'undefined') {
+                validator.validate(config)
+            } else {
+                name = resolveName(name as string)
+
+                validator.validate(name, get(data, name), config)
+            }
+
+            return form
+        },
+        get validating() {
+            return validating
+        },
+        valid(name: keyof Data) {
+            return valid.includes(resolveName(name as string))
+        },
+        invalid(name: keyof Data) {
+            return typeof form.errors[name] !== 'undefined'
+        },
+        get errors() {
+            return errors
+        },
+        get hasErrors() {
+            return hasErrors
+        },
+        setErrors(newErrors: any) {
+            validator.setErrors(newErrors)
+            return form
+        },
+        forgetError(name: keyof Data) {
+            validator.forgetError(name as string)
+
+            return form
+        },
+        reset(...names: (keyof Data & string)[]) {
+            const original = cloneDeep(originalData)
+
+            if (names.length === 0) {
+                originalInputs.forEach((name) => (data[name] = original[name]))
+            } else {
+                names.forEach((name: keyof Data) => set(data, name, get(original, name)))
+            }
+
+            validator.reset(...names)
+
+            return form
+        },
+        setValidationTimeout(duration: number) {
+            validator.setTimeout(duration)
+
+            return form
+        },
+        get processing() {
+            return processing
+        },
+        async submit(config = {}) {
+            return client[resolveMethod(method)](resolveUrl(url), form.data(), resolveSubmitConfig(config))
+        },
+        validateFiles() {
+            validator.validateFiles()
+
+            return form
+        },
+        validator() {
+            return validator
+        },
+    }
+
+    ;(Object.keys(data) as Array<keyof Data>).forEach((key) => {
+        Object.defineProperty(form, key, {
+            get() {
+                return data[key]
+            },
+            set(value: Data[keyof Data]) {
+                data[key] = value
+            },
+        })
+    })
+
+    return form as Data & Form<Data>
+}

--- a/packages/svelte/src/types.ts
+++ b/packages/svelte/src/types.ts
@@ -1,0 +1,22 @@
+import { client, type Config, type NamedInputEvent, type ValidationConfig, type Validator } from 'laravel-precognition'
+export { client }
+export interface Form<Data extends Record<string, unknown>> {
+    processing: boolean
+    validating: boolean
+    errors: Partial<Record<keyof Data, string>>
+    hasErrors: boolean
+    touched(name: keyof Data): boolean
+    touch(name: string | NamedInputEvent | Array<string>): Data & Form<Data>
+    data: () => Data
+    setData(data: Record<string, unknown>): Data & Form<Data>
+    valid(name: keyof Data): boolean
+    invalid(name: keyof Data): boolean
+    validate(name?: (keyof Data | NamedInputEvent) | ValidationConfig, config?: ValidationConfig): Data & Form<Data>
+    setErrors(errors: Partial<Record<keyof Data, string | string[]>>): Data & Form<Data>
+    forgetError(string: keyof Data | NamedInputEvent): Data & Form<Data>
+    setValidationTimeout(duration: number): Data & Form<Data>
+    submit(config?: Config): Promise<unknown>
+    reset(...keys: (keyof Partial<Data>)[]): Data & Form<Data>
+    validateFiles(): Data & Form<Data>
+    validator(): Validator
+}

--- a/packages/svelte/tsconfig.json
+++ b/packages/svelte/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "outDir": "./dist",
+        "target": "ES2020",
+        "module": "ES2020",
+        "moduleResolution": "node",
+        "resolveJsonModule": true,
+        "strict": true,
+        "declaration": true,
+        "esModuleInterop": true
+    },
+    "include": [
+        "./src/index.svelte.ts"
+    ]
+}


### PR DESCRIPTION
I've started working on this, as @renatomoor is unavailable. Svelte support was copied from #104.
My implementation is using svelte writable store, so it's consistent with the `useForm` from Inertia form helper.

```js
// Inertia Form Helper
const form = useForm({
    name: '',
    email: '',
    message: ''
});

// Precognition Form Helper
const form = useForm('post', '/contact', {
    name: '',
    email: '',
    message: ''
});
```

Accessing errors also exactly same as the inertia form helper:
```js
$form.errors.name
$form.valid('name')
$form.invalid('name')
```

Here's a repo with Inertia/Svelte already setup with simple form setup:
https://github.com/azatakmyradov/precogntion-testform

I tried to make it consistent with other precognition packages, but I haven't worked on NPM packages a lot, so let me know if I missed anything or any improvements I can make.