### PR TITLE
Vue-Inertia: Precognition-enabled Inertia Form component

### DIFF
--- a/packages/vue-inertia/src/form.ts
+++ b/packages/vue-inertia/src/form.ts
@@ -1,0 +1,104 @@
+import { defineComponent, h, PropType, ref } from 'vue'
+import { Form as InertiaForm } from '@inertiajs/vue3'
+import type { FormComponentProps, FormComponentSlotProps, FormDataConvertible } from '@inertiajs/core'
+import { formDataToObject, Method } from '@inertiajs/core'
+import type { ValidationConfig } from 'laravel-precognition'
+import { createValidator, toSimpleValidationErrors } from 'laravel-precognition'
+
+// Thin wrapper over Inertia's <Form> that wires Precognition live validation
+export const Form = defineComponent({
+  name: 'Form',
+  props: {
+    // Pass-through Inertia Form props (loosely typed to avoid duplication)
+    action: { type: [String, Object] as PropType<FormComponentProps['action']>, default: '' },
+    method: { type: String as PropType<FormComponentProps['method']>, default: 'get' },
+
+    // Live validation extras
+    precognitive: { type: [Boolean, Object] as PropType<boolean | ValidationConfig>, default: true },
+    validateOn: { type: [String, Array] as PropType<'input' | 'change' | 'blur' | Array<'input' | 'change' | 'blur'>>, default: 'change' },
+    validationTimeout: { type: Number, default: undefined },
+  },
+  setup(props, { slots, attrs }) {
+    const formRef = ref<any>(null)
+    let validator: ReturnType<typeof createValidator> | null = null
+
+    const getAction = () => (typeof props.action === 'object' ? props.action.url : (props.action as string))
+    const getMethod = () => ((typeof props.action === 'object' ? props.action.method : props.method).toLowerCase() as Method)
+
+    const ensureValidator = (formEl: HTMLFormElement) => {
+      if (validator) return validator
+      const initial = formDataToObject(new FormData(formEl)) as Record<string, FormDataConvertible>
+      validator = createValidator((client) => {
+        const current = formDataToObject(new FormData(formEl)) as Record<string, FormDataConvertible>
+        return client[getMethod()](getAction(), current, { precognitive: true })
+      }, initial)
+        .on('errorsChanged', () => {
+          const simple = toSimpleValidationErrors(validator!.errors()) as Record<string, string>
+          try {
+            formRef.value?.clearErrors()
+            formRef.value?.setError(simple)
+          } catch {}
+        })
+      if (typeof props.validationTimeout === 'number') {
+        validator.setTimeout(props.validationTimeout)
+      }
+      return validator
+    }
+
+    const shouldValidateField = (target: EventTarget | null) => {
+      const el = target as HTMLElement | null
+      if (!el) return false
+      return (
+        props.precognitive === true ||
+        typeof props.precognitive === 'object' ||
+        el.hasAttribute?.('precognitive') ||
+        el.hasAttribute?.('data-precognitive') ||
+        el.getAttribute?.('data-precognitive') === 'true'
+      )
+    }
+
+    const onMaybeValidate = (e: Event) => {
+      const evType = e.type as 'input' | 'change' | 'blur'
+      const types = Array.isArray(props.validateOn) ? props.validateOn : [props.validateOn]
+      if (!types.includes(evType)) return
+
+      const formEl = e.currentTarget as HTMLFormElement | null
+      if (!formEl || !shouldValidateField(e.target)) return
+
+      const v = ensureValidator(formEl)
+      const baseConfig = (typeof props.precognitive === 'object' ? props.precognitive : {}) as ValidationConfig
+
+      const target = e.target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement | null
+      const name = target ? target.name : undefined
+
+      try {
+        if (name) {
+          const data = formDataToObject(new FormData(formEl)) as Record<string, any>
+          v.validate(name, data[name], { ...baseConfig, precognitive: true })
+        } else {
+          v.validate({ ...baseConfig, precognitive: true })
+        }
+      } catch {}
+    }
+
+    return () =>
+      h(
+        InertiaForm as any,
+        {
+          ...attrs,
+          ref: formRef,
+          action: getAction(),
+          method: getMethod(),
+          onInput: onMaybeValidate,
+          onChange: onMaybeValidate,
+          onBlur: onMaybeValidate,
+        },
+        {
+          default: slots.default
+            ? (slotProps: FormComponentSlotProps) =>
+                slots.default?.({ ...slotProps, validating: validator?.validating() ?? false })
+            : undefined,
+        },
+      )
+  },
+})

--- a/packages/vue-inertia/src/types.ts
+++ b/packages/vue-inertia/src/types.ts
@@ -1,21 +1,22 @@
 import { NamedInputEvent, RequestMethod, SimpleValidationErrors, ValidationConfig, ValidationErrors } from 'laravel-precognition'
 import { Form as PrecognitiveForm } from 'laravel-precognition-vue/dist/types'
 import { InertiaForm } from '@inertiajs/vue3'
-import { VisitOptions } from '@inertiajs/core'
+import { VisitOptions, FormDataErrors, FormDataKeys } from '@inertiajs/core'
 
-type RedefinedProperties = 'setErrors' | 'touch' | 'forgetError' | 'setValidationTimeout' | 'submit' | 'reset' | 'validateFiles' | 'setData' | 'validate'
+type RedefinedProperties = 'setErrors' | 'touch' | 'forgetError' | 'setValidationTimeout' | 'submit' | 'reset' | 'validateFiles' | 'setData' | 'validate' | 'errors'
 
 export type Form<Data extends Record<string, FormDataConvertible>> = Omit<PrecognitiveForm<Data>, RedefinedProperties> & InertiaForm<Data> & {
+    errors: FormDataErrors<Data>,
     setErrors(errors: SimpleValidationErrors | ValidationErrors): Data & Form<Data>,
-    touch(name: Array<string> | string | NamedInputEvent): Data & Form<Data>,
-    forgetError(string: keyof Data | NamedInputEvent): Data & Form<Data>,
+    touch(name: Array<FormDataKeys<Data>> | FormDataKeys<Data> | NamedInputEvent): Data & Form<Data>,
+    forgetError(string: FormDataKeys<Data> | NamedInputEvent): Data & Form<Data>,
     setValidationTimeout(duration: number): Data & Form<Data>,
     submit(config?: Partial<VisitOptions>): void,
     submit(method: RequestMethod, url: string, options?: Partial<VisitOptions>): void,
-    reset(...keys: (keyof Partial<Data>)[]): Data & Form<Data>,
+    reset(...keys: FormDataKeys<Data>[]): Data & Form<Data>,
     validateFiles(): Data & Form<Data>,
     setData(data: Record<string, FormDataConvertible>): Data & Form<Data>,
-    validate(name?: (keyof Data | NamedInputEvent) | ValidationConfig, config?: ValidationConfig): Data & Form<Data>,
+    validate(name?: (FormDataKeys<Data> | NamedInputEvent) | ValidationConfig, config?: ValidationConfig): Data & Form<Data>,
 }
 
 // This type has been duplicated from @inertiajs/core to


### PR DESCRIPTION
## Motivation
Laravel 12 starter kits have moved from the Inertia useForm helper to the Inertia `<Form>` component. Inertia’s `<Form>` component does not support Precognition out of the box, making the Laravel 12 Vue starter kits incompatible with Laravel Precognition. This PR adds a thin wrapper over Inertia’s `<Form>` component to bridge that gap.

Key points
- Adds `<PrecognitionForm>` (re-export of named [Form] with live validation built-in.
- Per-field opt-in or global opt-in via props/attributes.
- Debounce configurable; errors normalized and synced; slot gets [validating].

Props
- action: string | { url: string; method: string }
- method: string (default: 'get') if using string action
- precognitive: boolean | ValidationConfig (default: true)
- validateOn: 'input' | 'change' | 'blur' | Array<'input'|'change'|'blur'> (default: 'change')
- validationTimeout: number | undefined

Per-field opt-in
- Add `precognitive` or `data-precognitive="true"` on inputs to validate that field (even if `precognitive=false` globally).

Usage: global live validation
```ts
<script setup lang="ts">
import { PrecognitionForm } from 'laravel-precognition-vue-inertia'
</script>

<template>
  <PrecognitionForm
    method="post"
    :action="route('register')"
    validate-on="change"
    :validation-timeout="500"
  >
    <template #default="{ data, setData, errors, hasErrors, processing, validating, submit }">
      <label>
        Name
        <input name="name" :value="data.name" @input="setData('name', $event.target.value)" />
        <span v-if="errors.name">{{ errors.name }}</span>
      </label>

      <label>
        Email
        <input name="email" :value="data.email" @input="setData('email', $event.target.value)" />
        <span v-if="errors.email">{{ errors.email }}</span>
      </label>

      <button :disabled="processing || validating" @click="submit()">Save</button>
    </template>
  </PrecognitionForm>
</template>
```

Usage: per-field opt-in + faster debounce
```ts
<PrecognitionForm
  method="patch"
  :action="route('profile.update')"
  :precognitive="false"
  :validate-on="['input','blur']"
  :validation-timeout="300"
>
  <template #default="{ data, setData, errors, validating, submit }">
    <input
      name="username"
      precognitive
      :value="data.username"
      @input="setData('username', $event.target.value)"
    />
    <span v-if="errors.username">{{ errors.username }}</span>

    <input
      name="bio"
      :value="data.bio"
      @input="setData('bio', $event.target.value)"
    />
    <!-- bio won't live-validate without per-field opt-in or precognitive=true -->

    <button :disabled="validating" @click="submit()">Update</button>
  </template>
</PrecognitionForm>
```

Usage: custom ValidationConfig (headers, hook)
```ts
<PrecognitionForm
  action="/api/users"
  method="post"
  :precognitive="{
    headers: { 'X-Extra': '1' },
    onValidationError: (res) => console.debug('precog error', res)
  }"
  validate-on="input"
  :validation-timeout="250"
>
  <template #default="{ data, setData, errors, validating, submit }">
    <!-- fields... -->
  </template>
</PrecognitionForm>
```

Notes
- Inputs must have a name attribute.
- Total latency = debounce + network + server. Tune `validationTimeout` for UX.