### PR TITLE
Support validating all fields when no or empty only property is passed

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -139,7 +139,7 @@ const resolveConfig = (config: Config): Config => {
             ...config.precognitive !== false ? {
                 Precognition: true,
             } : {},
-            ...only ? {
+            ...only && Array.from(only).length ? {
                 'Precognition-Validate-Only': Array.from(only).join(),
             } : {},
         },

--- a/packages/core/tests/validator.test.js
+++ b/packages/core/tests/validator.test.js
@@ -704,6 +704,22 @@ it('supports async validate with only key for untouched values', async () => {
     await assertPendingValidateDebounceAndClear()
 })
 
+it('supports async validate without only key', async () => {
+    let config
+    axios.request.mockImplementation((c) => {
+        config = c
+
+        return Promise.resolve({ headers: { precognition: 'true', 'precognition-success': 'true' }, status: 204, data: '' })
+    })
+    const validator = createValidator((client) => client.post('/foo', {}))
+
+    validator.validate()
+
+    expect(config.headers).not.toHaveProperty('Precognition-Validate-Only')
+
+    await assertPendingValidateDebounceAndClear()
+})
+
 it('supports async validate with depricated validate key for untouched values', async () => {
     let config
     axios.request.mockImplementation((c) => {


### PR DESCRIPTION
By calling `form.validate()` on a form that has not had any changes will force add the the Precognition-Validate-Only header to the async request and will be an empty string. Laravel on the backend checks that this header is preset and then uses it value to filter the validation rules down to only the fields present in this header. If this header is an empty string this will result in all fields being filtered out of the validation. By adding the Array.from(only) will convert ArrayLike and Iterable types into an array object, which fixes the ternary statement to resolve to the correct object.

Fixes #124 
