### PR TITLE
[2.x] Set `Accept` header to `application/json`

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -187,6 +187,7 @@ const resolveConfig = (config: Config): Config => {
             : config.fingerprint,
         headers: {
             ...config.headers,
+            'Accept': 'application/json',
             'Content-Type': resolveContentType(config),
             ...config.precognitive !== false ? {
                 Precognition: true,

--- a/packages/core/tests/axiosAdapter.test.js
+++ b/packages/core/tests/axiosAdapter.test.js
@@ -100,6 +100,27 @@ describe('axiosAdapter', () => {
         })
     })
 
+    it('forwards the Accept header when provided', async () => {
+        mockAxios.request.mockResolvedValueOnce({
+            status: 200,
+            data: {},
+            headers: {},
+        })
+
+        const adapter = axiosAdapter(mockAxios)
+        await adapter.request({
+            method: 'get',
+            url: '/api/users',
+            headers: { 'Accept': 'application/json' },
+        })
+
+        expect(mockAxios.request).toHaveBeenCalledWith(expect.objectContaining({
+            headers: expect.objectContaining({
+                'Accept': 'application/json',
+            }),
+        }))
+    })
+
     it('normalizes response headers to lowercase', async () => {
         mockAxios.request.mockResolvedValueOnce({
             status: 200,

--- a/packages/core/tests/client.test.js
+++ b/packages/core/tests/client.test.js
@@ -188,16 +188,20 @@ it('can handle a locked response via a config handler', async () => {
 })
 
 it('always sets the Accept header to application/json', async () => {
-    expect.assertions(1)
+    expect.assertions(2)
 
     let config
-    mockClient.mockImplementationOnce((c) => {
+    mockClient.mockImplementation((c) => {
         config = c
         return Promise.resolve({ headers: { precognition: 'true' }, status: 200, data: {} })
     })
 
     await client.get('https://laravel.com')
+    expect(config.headers['Accept']).toBe('application/json')
 
+    await client.get('https://laravel.com', {}, {
+        headers: { 'Accept': 'text/html' },
+    })
     expect(config.headers['Accept']).toBe('application/json')
 })
 

--- a/packages/core/tests/client.test.js
+++ b/packages/core/tests/client.test.js
@@ -187,6 +187,20 @@ it('can handle a locked response via a config handler', async () => {
     }).then((value) => expect(value).toBe('expected value'))
 })
 
+it('always sets the Accept header to application/json', async () => {
+    expect.assertions(1)
+
+    let config
+    mockClient.mockImplementationOnce((c) => {
+        config = c
+        return Promise.resolve({ headers: { precognition: 'true' }, status: 200, data: {} })
+    })
+
+    await client.get('https://laravel.com')
+
+    expect(config.headers['Accept']).toBe('application/json')
+})
+
 it('can provide input names to validate via config', async () => {
     expect.assertions(1)
 

--- a/packages/core/tests/fetchClient.test.js
+++ b/packages/core/tests/fetchClient.test.js
@@ -264,6 +264,32 @@ describe('fetchClient', () => {
         expect(callArgs.headers['Content-Type']).toBeUndefined()
     })
 
+    it('forwards the Accept header when provided', async () => {
+        global.fetch = vi.fn().mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            headers: new Headers({ 'content-type': 'application/json' }),
+            json: () => Promise.resolve({}),
+        })
+
+        await fetchHttpClient.request({
+            method: 'get',
+            url: 'https://laravel.com/api/users',
+            headers: {
+                'Accept': 'application/json',
+            },
+        })
+
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    'Accept': 'application/json',
+                }),
+            }),
+        )
+    })
+
     it('passes custom headers', async () => {
         global.fetch = vi.fn().mockResolvedValueOnce({
             ok: true,

--- a/packages/core/tests/validator.test.js
+++ b/packages/core/tests/validator.test.js
@@ -649,6 +649,7 @@ it('correctly merges config', async () => {
         'X-Local': '1',
         'X-Both': 'local',
         // others...
+        'Accept': 'application/json',
         'Content-Type': 'application/json',
         Precognition: true,
         'Precognition-Validate-Only': 'name',


### PR DESCRIPTION
This PR explicitly sets the `Accept: application/json` header on all Precognition requests.

In v1, Axios automatically included `application/json` in its default `Accept` header. The built-in fetch client in v2 does not set this by default, which may cause servers to return HTML instead of JSON.