### PR TITLE
Move axios adapter to a separate export

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,16 @@
     "author": "Laravel",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        },
+        "./axios": {
+            "types": "./dist/http/axiosAdapter.d.ts",
+            "default": "./dist/http/axiosAdapter.js"
+        }
+    },
     "files": [
         "/dist"
     ],

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,3 @@
-export { axiosAdapter, type AxiosHttpClient } from './http/axiosAdapter.js'
 export { client, resolveUrl, resolveMethod } from './client.js'
 export { createValidator, toSimpleValidationErrors, resolveName } from './validator.js'
 export { isFile } from './form.js'

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -10,6 +10,7 @@
         "esModuleInterop": true
     },
     "include": [
-        "./src/index.ts"
+        "./src/index.ts",
+        "./src/http/axiosAdapter.ts"
     ]
 }


### PR DESCRIPTION
This PR fixes a build error if axios isn't installed. It moves the axios adapter to a separate package export so it's only resolved when explicitly imported:

```js
// before:
import { axiosAdapter } from 'laravel-precognition'

// after:
import { axiosAdapter } from 'laravel-precognition/axios'
```
