### PR TITLE
Add Dependabot cooldown of 5 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 5
     # Only open pull requests for security updates...
     open-pull-requests-limit: 0
 
@@ -12,6 +14,8 @@ updates:
     directory: "/packages/core"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 5
     # Only open pull requests for security updates...
     open-pull-requests-limit: 0
 
@@ -19,6 +23,8 @@ updates:
     directory: "/packages/alpine"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 5
     # Only open pull requests for security updates...
     open-pull-requests-limit: 0
 
@@ -26,6 +32,8 @@ updates:
     directory: "/packages/react"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 5
     # Only open pull requests for security updates...
     open-pull-requests-limit: 0
 
@@ -33,6 +41,8 @@ updates:
     directory: "/packages/vue"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 5
     # Only open pull requests for security updates...
     open-pull-requests-limit: 0
 
@@ -40,6 +50,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
     groups:
       github-actions:
         patterns:
@@ -49,6 +61,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
     target-branch: "1.x"
     groups:
       github-actions:


### PR DESCRIPTION
This adds a 5-day cooldown to the Dependabot configuration so dependency update pull requests are only opened once an update has been available for 5 days. Applied to every update entry in `.github/dependabot.yml`.