### PR TITLE
Type every form field-name method with PrecognitionPath (+ indexed & record paths)

### DIFF
--- a/packages/alpine/src/types.ts
+++ b/packages/alpine/src/types.ts
@@ -3,19 +3,19 @@ import { Config, NamedInputEvent, PrecognitionPath, SimpleValidationErrors, Vali
 export interface Form<Data extends Record<string, unknown>> {
     processing: boolean,
     validating: boolean,
-    touched(name?: string): boolean,
+    touched(name?: PrecognitionPath<Data>): boolean,
     touch(name: string | NamedInputEvent | Array<string>): Data & Form<Data>,
     data(): Data,
     errors: Record<string, string>,
     hasErrors: boolean,
-    valid(name: string): boolean,
-    invalid(name: string): boolean,
+    valid(name: PrecognitionPath<Data>): boolean,
+    invalid(name: PrecognitionPath<Data>): boolean,
     validate(name?: PrecognitionPath<Data> | NamedInputEvent | ValidationConfig, config?: ValidationConfig): Data & Form<Data>,
     setErrors(errors: SimpleValidationErrors | ValidationErrors): Data & Form<Data>
-    forgetError(name: string | NamedInputEvent): Data & Form<Data>
+    forgetError(name: PrecognitionPath<Data> | NamedInputEvent): Data & Form<Data>
     setValidationTimeout(duration: number): Data & Form<Data>,
     submit(config?: Config): Promise<unknown>,
-    reset(...keys: string[]): Data & Form<Data>,
+    reset(...keys: PrecognitionPath<Data>[]): Data & Form<Data>,
     validateFiles(): Data & Form<Data>,
     withoutFileValidation(): Data & Form<Data>,
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -4,14 +4,71 @@ export * from './http/errors.js'
 import type { HttpClient, HttpResponse } from './http/types.js'
 import type { HttpResponseError } from './http/errors.js'
 
-type FormDataValue = string | number | boolean | null | undefined | Date | Blob | File | FileList
+type FormDataValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | Date
+  | Blob
+  | File
+  | FileList;
 
-export type PrecognitionPath<Data> = 0 extends 1 & Data ? never : Data extends object ? {
-    [K in Extract<keyof Data, string>]: 0 extends 1 & Data[K] ? never
-        : Data[K] extends Array<infer U>
-            ? K | `${K}.*` | (U extends FormDataValue ? never : `${K}.*.${Extract<keyof U, string>}` | `${K}.*.*`)
-            : Data[K] extends FormDataValue ? K : K | `${K}.*` | `${K}.${PrecognitionPath<Data[K]>}`
-}[Extract<keyof Data, string>] : never
+type OwnKeys<T> =
+  T extends Array<unknown>
+      ? Exclude<keyof T, keyof Array<unknown> | number>
+      : T extends object
+          ? {
+              [K in keyof T]: T[K] extends (...args: unknown[]) => unknown
+                  ? never
+                  : K;
+          }[keyof T]
+          : never;
+
+// Paths for a value indexable by number — an array or a `Record<number, U>`:
+// the key itself, a wildcard or numeric index, then (for non-leaf elements)
+// each sub-path, with "*" as the trailing segment matching every property.
+type IndexedPath<K extends string, U> =
+  | K
+  | `${K}.${'*' | number}`
+  | (U extends FormDataValue
+      ? never
+      : `${K}.${'*' | number}.${'*' | PrecognitionPath<U>}`);
+
+// Paths for a value indexable by string — a `Record<string, U>`. Keys are
+// unknown at compile time, so any string key is allowed (`${string}` also
+// covers the "*" wildcard). Sub-paths of the value stay typed, though a
+// `${string}` segment matches dots too, so deeper paths aren't fully checked.
+type StringIndexedPath<K extends string, U> =
+  | K
+  | `${K}.${string}`
+  | (U extends FormDataValue
+      ? never
+      : `${K}.${string}.${'*' | PrecognitionPath<U>}`);
+
+export type PrecognitionPath<Data> = 0 extends 1 & Data
+    ? never
+    : Data extends object
+        ? {
+            [K in Extract<OwnKeys<Data>, string>]: 0 extends 1 & Data[K]
+                ? never
+                : // leaf value first: `string` is numerically indexable (keyof string
+            // includes number), so it must be caught before the index checks
+                NonNullable<Data[K]> extends FormDataValue
+                    ? K
+                    : // string-keyed record (Record<string, U>) — checked before the
+                // numeric one, which it also satisfies
+                    string extends keyof NonNullable<Data[K]>
+                        ? StringIndexedPath<K, NonNullable<Data[K]>[string]>
+                        : // array or numeric-keyed record (Record<number, U>)
+                        number extends keyof NonNullable<Data[K]>
+                            ? IndexedPath<K, NonNullable<Data[K]>[number]>
+                            : // nested object: the key, a one-level wildcard (profile.*), or each sub-path
+                    K | `${K}.${'*' | PrecognitionPath<NonNullable<Data[K]>>}`;
+        }[Extract<OwnKeys<Data>, string>]
+        : never;
+
 
 export type StatusHandler = (response: HttpResponse, error?: HttpResponseError) => unknown
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -26,9 +26,7 @@ type OwnKeys<T> =
           }[keyof T]
           : never;
 
-// Paths for a value indexable by number — an array or a `Record<number, U>`:
-// the key itself, a wildcard or numeric index, then (for non-leaf elements)
-// each sub-path, with "*" as the trailing segment matching every property.
+// Paths for an array or a numeric-keyed record (Record<number, U>)
 type IndexedPath<K extends string, U> =
   | K
   | `${K}.${'*' | number}`
@@ -36,10 +34,10 @@ type IndexedPath<K extends string, U> =
       ? never
       : `${K}.${'*' | number}.${'*' | PrecognitionPath<U>}`);
 
-// Paths for a value indexable by string — a `Record<string, U>`. Keys are
-// unknown at compile time, so any string key is allowed (`${string}` also
-// covers the "*" wildcard). Sub-paths of the value stay typed, though a
-// `${string}` segment matches dots too, so deeper paths aren't fully checked.
+// Paths for a string-keyed record (Record<string, U>). Keys are unknown at
+// compile time, so any string key is allowed and `${string}` covers the "*"
+// wildcard. Sub-paths stay typed, but a `${string}` segment matches dots too,
+// so deeper paths aren't fully checked.
 type StringIndexedPath<K extends string, U> =
   | K
   | `${K}.${string}`
@@ -47,25 +45,25 @@ type StringIndexedPath<K extends string, U> =
       ? never
       : `${K}.${string}.${'*' | PrecognitionPath<U>}`);
 
+// Build every valid path for a form data object
 export type PrecognitionPath<Data> = 0 extends 1 & Data
     ? never
     : Data extends object
         ? {
             [K in Extract<OwnKeys<Data>, string>]: 0 extends 1 & Data[K]
                 ? never
-                : // leaf value first: `string` is numerically indexable (keyof string
-            // includes number), so it must be caught before the index checks
-                NonNullable<Data[K]> extends FormDataValue
+                // Leaf value first. A `string` is numerically indexable (keyof
+                // string includes number), so we catch it before the index checks.
+                : NonNullable<Data[K]> extends FormDataValue
                     ? K
-                    : // string-keyed record (Record<string, U>) — checked before the
-                // numeric one, which it also satisfies
-                    string extends keyof NonNullable<Data[K]>
+                    // String-keyed record, checked before the numeric one it also satisfies
+                    : string extends keyof NonNullable<Data[K]>
                         ? StringIndexedPath<K, NonNullable<Data[K]>[string]>
-                        : // array or numeric-keyed record (Record<number, U>)
-                        number extends keyof NonNullable<Data[K]>
+                        // Array or numeric-keyed record
+                        : number extends keyof NonNullable<Data[K]>
                             ? IndexedPath<K, NonNullable<Data[K]>[number]>
-                            : // nested object: the key, a one-level wildcard (profile.*), or each sub-path
-                    K | `${K}.${'*' | PrecognitionPath<NonNullable<Data[K]>>}`;
+                            // Nested object: the key, a one-level wildcard (profile.*), or each sub-path
+                            : K | `${K}.${'*' | PrecognitionPath<NonNullable<Data[K]>>}`;
         }[Extract<OwnKeys<Data>, string>]
         : never;
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -27,6 +27,7 @@ type OwnKeys<T> =
           : never;
 
 // Paths for an array or a numeric-keyed record (Record<number, U>)
+// e.g. "users", "users.*", "users.0", "users.*.name", "users.0.name"
 type IndexedPath<K extends string, U> =
   | K
   | `${K}.${'*' | number}`
@@ -38,6 +39,7 @@ type IndexedPath<K extends string, U> =
 // compile time, so any string key is allowed and `${string}` covers the "*"
 // wildcard. Sub-paths stay typed, but a `${string}` segment matches dots too,
 // so deeper paths aren't fully checked.
+// e.g. "meta", "meta.locale", "meta.*.label"
 type StringIndexedPath<K extends string, U> =
   | K
   | `${K}.${string}`
@@ -45,7 +47,9 @@ type StringIndexedPath<K extends string, U> =
       ? never
       : `${K}.${string}.${'*' | PrecognitionPath<U>}`);
 
-// Build every valid path for a form data object
+// Build every valid path for a form data object, e.g. for
+// { name: string; profile: { bio: string }; users: { name: string }[] }
+// this yields "name", "profile", "profile.bio", "users", "users.*.name", etc.
 export type PrecognitionPath<Data> = 0 extends 1 & Data
     ? never
     : Data extends object
@@ -54,15 +58,19 @@ export type PrecognitionPath<Data> = 0 extends 1 & Data
                 ? never
                 // Leaf value first. A `string` is numerically indexable (keyof
                 // string includes number), so we catch it before the index checks.
+                // e.g. "name", "email"
                 : NonNullable<Data[K]> extends FormDataValue
                     ? K
                     // String-keyed record, checked before the numeric one it also satisfies
+                    // e.g. "meta.locale", "meta.*.label"
                     : string extends keyof NonNullable<Data[K]>
                         ? StringIndexedPath<K, NonNullable<Data[K]>[string]>
                         // Array or numeric-keyed record
+                        // e.g. "users.*", "users.0.name"
                         : number extends keyof NonNullable<Data[K]>
                             ? IndexedPath<K, NonNullable<Data[K]>[number]>
-                            // Nested object: the key, a one-level wildcard (profile.*), or each sub-path
+                            // Nested object: the key, a one-level wildcard, or each sub-path
+                            // e.g. "profile", "profile.*", "profile.name"
                             : K | `${K}.${'*' | PrecognitionPath<NonNullable<Data[K]>>}`;
         }[Extract<OwnKeys<Data>, string>]
         : never;

--- a/packages/core/tests/types.test-d.ts
+++ b/packages/core/tests/types.test-d.ts
@@ -1,0 +1,147 @@
+import { describe, it, expectTypeOf } from 'vitest'
+import type { PrecognitionPath } from '../src/index.js'
+
+type Company = {
+    name: string;
+    addresses: string[];
+};
+
+type Data = {
+    name: string;
+    profile: {
+        age: number;
+        city: string;
+    };
+    users: { name: string; email: string }[];
+    tags: string[];
+    company: Company;
+    nested: {
+        companies: Company[];
+    };
+    meta: Record<string, string>;
+    scores: Record<number, number>;
+};
+
+type Path = PrecognitionPath<Data>
+
+describe('PrecognitionPath accepts valid paths', () => {
+    it('top-level leaf and object/array roots', () => {
+        expectTypeOf<'name'>().toExtend<Path>()
+        expectTypeOf<'profile'>().toExtend<Path>()
+        expectTypeOf<'users'>().toExtend<Path>()
+        expectTypeOf<'tags'>().toExtend<Path>()
+        expectTypeOf<'company'>().toExtend<Path>()
+    })
+
+    it('nested object paths', () => {
+        expectTypeOf<'profile.age'>().toExtend<Path>()
+        expectTypeOf<'profile.city'>().toExtend<Path>()
+        expectTypeOf<'profile.*'>().toExtend<Path>()
+        expectTypeOf<'company.name'>().toExtend<Path>()
+        expectTypeOf<'company.addresses'>().toExtend<Path>()
+    })
+
+    it('array wildcard paths', () => {
+        expectTypeOf<'users.*'>().toExtend<Path>()
+        expectTypeOf<'users.*.name'>().toExtend<Path>()
+        expectTypeOf<'users.*.email'>().toExtend<Path>()
+        expectTypeOf<'users.*.*'>().toExtend<Path>()
+        expectTypeOf<'tags.*'>().toExtend<Path>()
+    })
+
+    it('indexed element paths', () => {
+        expectTypeOf<'users.0'>().toExtend<Path>()
+        expectTypeOf<'users.0.name'>().toExtend<Path>()
+        expectTypeOf<'users.0.email'>().toExtend<Path>()
+        expectTypeOf<'users.42.name'>().toExtend<Path>()
+        expectTypeOf<'tags.0'>().toExtend<Path>()
+    })
+
+    it('deeply nested array-of-object paths', () => {
+        expectTypeOf<'nested'>().toExtend<Path>()
+        expectTypeOf<'nested.companies'>().toExtend<Path>()
+        expectTypeOf<'nested.companies.*'>().toExtend<Path>()
+        expectTypeOf<'nested.companies.0'>().toExtend<Path>()
+        expectTypeOf<'nested.companies.*.name'>().toExtend<Path>()
+        expectTypeOf<'nested.companies.0.name'>().toExtend<Path>()
+        expectTypeOf<'nested.companies.*.addresses'>().toExtend<Path>()
+        expectTypeOf<'nested.companies.0.addresses'>().toExtend<Path>()
+    })
+
+    it('record-keyed paths', () => {
+        expectTypeOf<'meta'>().toExtend<Path>()
+        expectTypeOf<'meta.anyKey'>().toExtend<Path>()
+        expectTypeOf<'scores'>().toExtend<Path>()
+        expectTypeOf<'scores.0'>().toExtend<Path>()
+    })
+})
+
+describe('PrecognitionPath rejects invalid paths', () => {
+    it('nonexistent fields', () => {
+        // @ts-expect-error - no such top-level field
+        expectTypeOf<'nonexistent'>().toExtend<Path>()
+        // @ts-expect-error - no such nested field
+        expectTypeOf<'profile.country'>().toExtend<Path>()
+        // @ts-expect-error - no such property on array items
+        expectTypeOf<'users.*.unknown'>().toExtend<Path>()
+        // @ts-expect-error - no such property on indexed item
+        expectTypeOf<'users.0.unknown'>().toExtend<Path>()
+    })
+
+    it('paths into leaf values', () => {
+        // @ts-expect-error - age is a number, has no sub-paths
+        expectTypeOf<'profile.age.foo'>().toExtend<Path>()
+        // @ts-expect-error - a leaf has no wildcard children
+        expectTypeOf<'profile.*.*'>().toExtend<Path>()
+    })
+
+    it('missing index/wildcard for array access', () => {
+        // @ts-expect-error - array item field needs an index or wildcard
+        expectTypeOf<'users.name'>().toExtend<Path>()
+        // @ts-expect-error - array item field needs an index or wildcard
+        expectTypeOf<'users.email'>().toExtend<Path>()
+    })
+
+    it('array built-ins and methods are not paths', () => {
+        // @ts-expect-error - Array.length is not a field
+        expectTypeOf<'users.length'>().toExtend<Path>()
+        // @ts-expect-error - Array.push is not a field
+        expectTypeOf<'users.push'>().toExtend<Path>()
+        // @ts-expect-error - Array.map is not a field
+        expectTypeOf<'tags.map'>().toExtend<Path>()
+    })
+})
+
+type Errors = Partial<Record<Path, string>>
+
+describe('PrecognitionPath in record-key position (errors / setErrors)', () => {
+    it('accepts valid keys in an object literal', () => {
+        expectTypeOf<{
+            'name': string;
+            'profile.age': string;
+            'users.0.name': string;
+            'users.*.name': string;
+            'company.name': string;
+            'meta.anyKey': string;
+        }>().toExtend<Errors>()
+    })
+
+    it('rejects unknown keys in an object literal', () => {
+        const errors: Errors = {
+            // @ts-expect-error - no such path
+            'users.0.unknown': 'Required',
+        }
+        return errors
+    })
+
+    it('accepts indexed access by a valid path', () => {
+        expectTypeOf<Errors['users.0.name']>().toEqualTypeOf<string | undefined>()
+        expectTypeOf<Errors['profile.age']>().toEqualTypeOf<string | undefined>()
+    })
+
+    it('rejects indexed access by an invalid path', () => {
+        // @ts-expect-error - no such path
+        expectTypeOf<Errors['users.0.unknown']>()
+    })
+
+})

--- a/packages/core/tsconfig.vitest.json
+++ b/packages/core/tsconfig.vitest.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.json",
+    "include": [
+        "./src/**/*.ts",
+        "./tests/**/*.test-d.ts"
+    ]
+}

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+    test: {
+        typecheck: {
+            enabled: true,
+            include: ['**/*.test-d.ts'],
+            tsconfig: './tsconfig.vitest.json',
+        },
+    },
+})

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -34,12 +34,12 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
     /**
      * The reactive valid state.
      */
-    const [valid, setValid] = useState<(keyof Partial<Data>)[]>([])
+    const [valid, setValid] = useState<string[]>([])
 
     /**
      * The reactive touched state.
      */
-    const [touched, setTouched] = useState<(keyof Partial<Data>)[]>([])
+    const [touched, setTouched] = useState<string[]>([])
 
     /**
      * The reactive validating state.
@@ -54,7 +54,7 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
     /**
      * The reactive errors state.
      */
-    const [errors, setErrors] = useState<Partial<Record<keyof Data, string>>>({})
+    const [errors, setErrors] = useState<Partial<Record<string, string>>>({})
 
     /**
      * The reactive hasErrors state.
@@ -85,7 +85,6 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
             .on('errorsChanged', () => {
                 setHasErrors(validator.current!.hasErrors())
 
-                // @ts-expect-error
                 setErrors(toSimpleValidationErrors(validator.current!.errors()))
 
                 setValid(validator.current!.valid())
@@ -181,7 +180,6 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
             return form
         },
         forgetError(name) {
-            // @ts-expect-error
             validator.current!.forgetError(name)
 
             return form
@@ -199,7 +197,6 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
                 setData(payload.current)
             }
 
-            // @ts-expect-error
             validator.current!.reset(...names)
 
             return form

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -3,20 +3,20 @@ import { Config, NamedInputEvent, PrecognitionPath, ValidationConfig, Validator 
 export interface Form<Data extends Record<string, unknown>> {
     processing: boolean,
     validating: boolean,
-    touched(name?: keyof Data): boolean,
+    touched(name?: PrecognitionPath<Data>): boolean,
     touch(name: string | NamedInputEvent | Array<string>): Form<Data>,
     data: Data,
     setData(key: Data | keyof Data, value?: unknown): Form<Data>,
-    errors: Partial<Record<keyof Data, string>>,
+    errors: Partial<Record<PrecognitionPath<Data>, string>>,
     hasErrors: boolean,
-    valid(name: keyof Data): boolean,
-    invalid(name: keyof Data): boolean,
+    valid(name: PrecognitionPath<Data>): boolean,
+    invalid(name: PrecognitionPath<Data>): boolean,
     validate(name?: PrecognitionPath<Data> | NamedInputEvent | ValidationConfig, config?: ValidationConfig): Form<Data>,
-    setErrors(errors: Partial<Record<keyof Data, string | string[]>>): Form<Data>
-    forgetError(string: keyof Data | NamedInputEvent): Form<Data>
+    setErrors(errors: Partial<Record<PrecognitionPath<Data>, string | string[]>>): Form<Data>
+    forgetError(string: PrecognitionPath<Data> | NamedInputEvent): Form<Data>
     setValidationTimeout(duration: number): Form<Data>,
     submit(config?: Config): Promise<unknown>,
-    reset(...names: (keyof Partial<Data>)[]): Form<Data>,
+    reset(...names: (PrecognitionPath<Data>)[]): Form<Data>,
     validateFiles(): Form<Data>,
     withoutFileValidation(): Form<Data>,
     validator(): Validator,

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -21,12 +21,12 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
     /**
      * Reactive valid state.
      */
-    const valid = ref<(keyof Data)[]>([])
+    const valid = ref<string[]>([])
 
     /**
      * Reactive touched state.
      */
-    const touched = ref<(keyof Partial<Data>)[]>([])
+    const touched = ref<string[]>([])
 
     /**
      * The validator instance.
@@ -98,7 +98,6 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
         },
         touched(name) {
             if (typeof name === 'string') {
-                // @ts-expect-error
                 return touched.value.includes(name)
             } else {
                 return touched.value.length > 0
@@ -127,7 +126,6 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
         },
         validating: false,
         valid(name) {
-            // @ts-expect-error
             return valid.value.includes(name)
         },
         invalid(name) {
@@ -142,7 +140,6 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
             return form
         },
         forgetError(name) {
-            // @ts-expect-error
             validator.forgetError(name)
 
             return form
@@ -157,7 +154,6 @@ export const useForm = <Data extends Record<string, unknown>>(method: RequestMet
                 names.forEach((name) => set(form, name, get(original, name)))
             }
 
-            // @ts-expect-error
             validator.reset(...names)
 
             return form

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -3,20 +3,20 @@ import { ValidationConfig, Config, NamedInputEvent, PrecognitionPath, Validator 
 export interface Form<Data extends Record<string, unknown>> {
     processing: boolean,
     validating: boolean,
-    touched(name?: keyof Data): boolean,
+    touched(name?: PrecognitionPath<Data>): boolean,
     touch(name: string | NamedInputEvent | Array<string>): Data & Form<Data>,
     data(): Data,
     setData(data: Record<string, unknown>): Data & Form<Data>,
-    errors: Partial<Record<keyof Data, string>>,
+    errors: Partial<Record<PrecognitionPath<Data>, string>>,
     hasErrors: boolean,
-    valid(name: keyof Data): boolean,
-    invalid(name: keyof Data): boolean,
+    valid(name: PrecognitionPath<Data>): boolean,
+    invalid(name: PrecognitionPath<Data>): boolean,
     validate(name?: PrecognitionPath<Data> | NamedInputEvent | ValidationConfig, config?: ValidationConfig): Data & Form<Data>,
-    setErrors(errors: Partial<Record<keyof Data, string | string[]>>): Data & Form<Data>
-    forgetError(string: keyof Data | NamedInputEvent): Data & Form<Data>
+    setErrors(errors: Partial<Record<PrecognitionPath<Data>, string | string[]>>): Data & Form<Data>
+    forgetError(string: PrecognitionPath<Data> | NamedInputEvent): Data & Form<Data>
     setValidationTimeout(duration: number): Data & Form<Data>,
     submit(config?: Config): Promise<unknown>,
-    reset(...keys: (keyof Partial<Data>)[]): Data & Form<Data>,
+    reset(...keys: (PrecognitionPath<Data>)[]): Data & Form<Data>,
     validateFiles(): Data & Form<Data>,
     withoutFileValidation(): Data & Form<Data>,
     validator(): Validator,


### PR DESCRIPTION
## Summary
PrecognitionPath was introduced in #137 to give validate() autocompletion and typo-checking for nested/wildcard field paths, but the work was incomplete:

- It was only wired into `validate()`. The other field-name methods — `touched,` `valid`, `invalid`, `errors`, `setErrors`, `forgetError`, `reset` — still used `keyof Data` (Vue/React) or string (Alpine). So they rejected the very paths validate() accepts: you could `validate('profile.name')` but `valid('profile.name')` failed to type-check.
- The path type couldn't target a specific list element (`users.0.name`), didn't handle string/number-keyed records, and surfaced array built-ins (`length`, `push`, …) as valid paths.

## Changes

**core**
- Extend PrecognitionPath to:
  - accept a specific index (`users.0.name`) alongside wildcards (users.*.name)
- support `Record<string, U>` and `Record<number, U>`
  - exclude array built-ins (`length`, `push`, `map`, …) and methods via a new `OwnKeys` helper vue / react / alpine
  
**vue / react / alpine**

- Type all field-name methods with `PrecognitionPath<Data>`, for parity with `validate()`.
- Internally, the `valid/touched` state (and React's errors store) are typed with string keys to mirror the validator's runtime return (`Array<string>` / `Record<string,string>`), which removes the now-obsolete @ts-expect-error directives. No runtime change.

## Example

```ts
const form = useForm('post', '/users', {
    profile: { age: 0 },
    users: [{ name: '' }],
})

// 1) Consistency — paths validate() already accepted, now accepted everywhere
form.validate('profile.age') // ✅ before & after
form.valid('profile.age')    // ❌ rejected before (keyof Data) → ✅ now
form.errors['profile.age']   // ❌ rejected before → ✅ now

// 2) New — target a specific list element by index
//    (previously the wildcard was the only option, including in validate())
form.validate('users.0.name') // ❌ rejected before → ✅ now
form.valid('users.0.name')    // ✅ now

// Array built-ins are still correctly rejected
form.touched('users.length')  // ❌ type error
```

## Alternative considered: plain string
Another option would be to type these parameters as string everywhere (as Alpine originally did). Field paths only matter at the validation layer, and TypeScript types are erased at runtime — so a path that doesn't exist is a silent no-op either way, never a runtime error. Using string would fix the "valid paths rejected" issue with zero added type complexity.

This PR keeps `PrecognitionPath` instead because:

- it was already the contract for validate() (#137), so switching to string would be a DX regression — removing a typed surface rather than completing it;
- it turns an otherwise silent mistake (a mistyped field name) into a compile-time error, and provides autocompletion.

Happy to move everything to string if maintainers prefer the simpler surface — it's a one-line type change per method.
