### PR TITLE
Add continuous preview releases with pkg.pr.new

### DIFF
--- a/.github/workflows/continuous-releases.yml
+++ b/.github/workflows/continuous-releases.yml
@@ -1,0 +1,49 @@
+name: continuous releases
+
+on:
+  push:
+    branches:
+      - main
+      - '*.x'
+  pull_request:
+
+permissions: {}
+
+concurrency:
+  group: pkg-pr-new-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    # Runs automatically on the canonical repository. To use it on a fork,
+    # install the pkg.pr.new GitHub App on the fork and add a repository
+    # variable named PKG_PR_NEW set to "true". Other forks stay opted out,
+    # so they don't get failing runs.
+    if: github.repository == 'laravel/precognition' || vars.PKG_PR_NEW == 'true'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22.x
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build packages
+        run: npm run build
+
+      - name: Publish preview packages
+        run: >
+          npx pkg-pr-new publish --packageManager=npm
+          './packages/core'
+          './packages/react'
+          './packages/vue'
+          './packages/alpine'


### PR DESCRIPTION
## What

This PR sets up [pkg.pr.new](https://github.com/stackblitz-labs/pkg.pr.new) so every push to `main`/`*.x` and every pull request publishes ready-to-install preview packages. Each run drops a comment with install URLs, so anyone can try the exact build in seconds:

  ```bash
  npm i https://pkg.pr.new/laravel-precognition@<sha>
  npm i https://pkg.pr.new/laravel-precognition-vue@<sha>
  ```

No version bumps, no npm publish, no `next`/`canary` tag juggling. I've already run it end-to-end on my fork and the URLs install cleanly : https://github.com/messenjer/precognition/pull/1/checks 

pkg.pr.new is a well-established "Continuous Releases" tool, already used by major OSS projects like [Vite](https://github.com/vitejs/vite), [Vue](https://github.com/vuejs/core), Nuxt, and many more, so it's battle-tested at scale.

## Why

Today, trying out a change that's merged on `2.x` but not yet released means cloning the repo and `npm link`-ing every workspace by hand. I ran into this wanting to test a couple of recent fixes:

  - #150
  - #156

With preview releases, contributors and users can validate this kind of work against their own app before a release ships, and PR reviews get a lot easier when you can just install the branch.

## Setup

The workflow is ready to go - the only manual step is enabling the app on the repo (a maintainer action, since it needs org/repo admin):

1. Install the [pkg.pr.new GitHub App](https://github.com/apps/pkg-pr-new) and grant it access to `laravel/precognition`.
2. That's it - the next push or PR triggers the `continuous releases` workflow and posts the install URLs automatically. No tokens or secrets to configure.

Full instructions: the [pkg.pr.new setup guide](https://github.com/stackblitz-labs/pkg.pr.new#-setup).

  **Using it on a fork?** The job is gated to `laravel/precognition` by default. To run it on a fork, install the app on your fork and add a repository variable `PKG_PR_NEW` set to `true` (Settings → Secrets and variables → Actions → Variables). That opt-in is what lets the workflow publish from your fork without other forks getting failing CI.